### PR TITLE
Store token and reuse until it expires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,6 @@ select = [
     "S", # bandit
     "UP", # pyupgrade
 ]
-ignore = [
-    "S107", "S602", "S603", "S608"
-]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,9 @@ dependencies = [
     "pydantic",
     "pydantic-settings",
     "uvicorn",
-    "fastapi"
+    "fastapi",
+    "cryptography>=3.0",
+    "pyjwt",
 ]
 authors = [
     {name = "Open Brain Institute", email = "info@openbraininstitute.org"}
@@ -127,6 +129,7 @@ precision = 0
 fail_under = 50
 
 [tool.mypy]
+plugins = ["pydantic.mypy"]
 show_error_codes = true
 ignore_missing_imports = true
 allow_redefinition = true

--- a/src/obi_auth/cache.py
+++ b/src/obi_auth/cache.py
@@ -22,7 +22,7 @@ class TokenCache:
 
     def get(self) -> str | None:
         """Get a cached token if valid, else None."""
-        if self._storage.exists():
+        if not self._storage.exists():
             return None
         try:
             token_info = self._storage.read()

--- a/src/obi_auth/cache.py
+++ b/src/obi_auth/cache.py
@@ -5,9 +5,9 @@ from datetime import UTC, datetime
 import jwt
 from cryptography.fernet import Fernet, InvalidToken
 
-from obi_auth.config import settings
 from obi_auth.storage import Storage
 from obi_auth.typedef import TokenInfo
+from obi_auth.util import derive_fernet_key
 
 
 class TokenCache:
@@ -17,14 +17,13 @@ class TokenCache:
 
     def __init__(self):
         """Initialize the token cache."""
-        self._cipher = Fernet(key=settings.secret_key)
+        self._cipher = Fernet(key=derive_fernet_key())
 
     def get(self, storage: Storage) -> str | None:
         """Get a cached token if valid, else None."""
-        if not storage.exists():
+        if not (token_info := storage.read()):
             return None
         try:
-            token_info = storage.read()
             return self._cipher.decrypt_at_time(
                 token=token_info.token,
                 ttl=token_info.ttl,

--- a/src/obi_auth/cache.py
+++ b/src/obi_auth/cache.py
@@ -17,8 +17,8 @@ class TokenCache:
 
     def __init__(self, storage: Storage):
         """Initialize the token cache."""
-        self._cipher = Fernet(key=settings.secret_key)
         self._storage = storage
+        self._cipher = Fernet(key=settings.secret_key)
 
     def get(self) -> str | None:
         """Get a cached token if valid, else None."""

--- a/src/obi_auth/cache.py
+++ b/src/obi_auth/cache.py
@@ -1,6 +1,6 @@
 """Token cache module."""
 
-from datetime import UTC, datetime
+import time
 
 import jwt
 from cryptography.fernet import Fernet, InvalidToken
@@ -49,7 +49,7 @@ class TokenCache:
 
 def _now() -> int:
     """Return UTC timestamp now."""
-    return int(datetime.now(UTC).timestamp())
+    return int(time.time())
 
 
 def _get_token_times(token: str) -> tuple[int, int]:

--- a/src/obi_auth/cache.py
+++ b/src/obi_auth/cache.py
@@ -22,7 +22,7 @@ class TokenCache:
 
     def get(self) -> str | None:
         """Get a cached token if valid, else None."""
-        if self._storage.empty():
+        if self._storage.exists():
             return None
         try:
             token_info = self._storage.read()

--- a/src/obi_auth/cache.py
+++ b/src/obi_auth/cache.py
@@ -1,0 +1,67 @@
+"""Token cache module."""
+
+from datetime import UTC, datetime
+
+import jwt
+from cryptography.fernet import Fernet, InvalidToken
+from pydantic import BaseModel
+
+from obi_auth.config import settings
+
+
+class TokenInfo(BaseModel):
+    """Token information."""
+
+    token: bytes
+    ttl: int
+
+
+class TokenCache:
+    """Token cache."""
+
+    token_info: TokenInfo | None = None
+
+    def __init__(self):
+        """Initialize the token cache."""
+        self._cipher = Fernet(key=settings.secret_key)
+
+    def get(self) -> str | None:
+        """Get a cached token if valid, else None."""
+        if self.token_info is None:
+            return None
+        try:
+            return self._cipher.decrypt_at_time(
+                token=self.token_info.token,
+                ttl=self.token_info.ttl,
+                current_time=_now(),
+            ).decode()
+        except InvalidToken:
+            self.clear()
+            return None
+
+    def clear(self):
+        """Clear the cached token."""
+        self.token_info = None
+
+    def set(self, token: str) -> None:
+        """Store a new token in the cache."""
+        creation_time, time_to_live = _get_token_times(token)
+        fernet_token: bytes = self._cipher.encrypt_at_time(
+            data=token.encode(encoding="utf-8"),
+            current_time=creation_time,
+        )
+        self.token_info = TokenInfo(
+            token=fernet_token,
+            ttl=time_to_live,
+        )
+
+
+def _now() -> int:
+    """Return UTC timestamp now."""
+    return int(datetime.now(UTC).timestamp())
+
+
+def _get_token_times(token: str) -> tuple[int, int]:
+    """Get the creation time and time to live of a token."""
+    info = jwt.decode(token.encode(), options={"verify_signature": False})
+    return info["iat"], info["exp"] - info["iat"]

--- a/src/obi_auth/client.py
+++ b/src/obi_auth/client.py
@@ -3,15 +3,17 @@
 import logging
 
 from obi_auth.cache import TokenCache
+from obi_auth.config import settings
 from obi_auth.exception import AuthFlowError, ClientError, ConfigError, LocalServerError
 from obi_auth.flow import pkce_authenticate
 from obi_auth.server import AuthServer
+from obi_auth.storage import Storage
 from obi_auth.typedef import DeploymentEnvironment
 
 L = logging.getLogger(__name__)
 
 
-_TOKEN_CACHE = TokenCache()
+_TOKEN_CACHE = TokenCache(storage=Storage(file_path=settings.config_path))
 
 
 def get_token(*, environment: DeploymentEnvironment | None = None) -> str | None:

--- a/src/obi_auth/config.py
+++ b/src/obi_auth/config.py
@@ -8,7 +8,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from obi_auth.exception import ConfigError
 from obi_auth.typedef import DeploymentEnvironment, KeycloakRealm
-from obi_auth.util import derive_fernet_key, get_config_dir
+from obi_auth.util import get_config_dir
 
 
 class Settings(BaseSettings):
@@ -21,14 +21,6 @@ class Settings(BaseSettings):
         case_sensitive=False,
         validate_default=False,
     )
-
-    secret_key: Annotated[
-        str | bytes,
-        Field(
-            description="Key to use for encrypting/decrypting tokens.",
-            default_factory=derive_fernet_key,
-        ),
-    ]  # noqa: call-arg
 
     config_dir: Annotated[
         Path,

--- a/src/obi_auth/config.py
+++ b/src/obi_auth/config.py
@@ -1,5 +1,9 @@
 """This module provides a config for the obi_auth service."""
 
+from typing import Annotated
+
+from cryptography.fernet import Fernet
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from obi_auth.exception import ConfigError
@@ -13,8 +17,17 @@ class Settings(BaseSettings):
         env_file=".env",
         env_prefix="OBI_AUTH_",
         env_file_encoding="utf-8",
-        case_sensitive=True,
+        case_sensitive=False,
+        validate_default=False,
     )
+
+    secret_key: Annotated[
+        str | bytes,
+        Field(
+            description="Key to use for encrypting/decrypting tokens.",
+            default_factory=Fernet.generate_key,
+        ),
+    ]  # noqa: call-arg
 
     KEYCLOAK_ENV: DeploymentEnvironment = DeploymentEnvironment.staging
     KEYCLOAK_REALM: KeycloakRealm = KeycloakRealm.sbo

--- a/src/obi_auth/config.py
+++ b/src/obi_auth/config.py
@@ -1,13 +1,14 @@
 """This module provides a config for the obi_auth service."""
 
+from pathlib import Path
 from typing import Annotated
 
-from cryptography.fernet import Fernet
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from obi_auth.exception import ConfigError
 from obi_auth.typedef import DeploymentEnvironment, KeycloakRealm
+from obi_auth.util import derive_fernet_key, get_config_path
 
 
 class Settings(BaseSettings):
@@ -25,9 +26,17 @@ class Settings(BaseSettings):
         str | bytes,
         Field(
             description="Key to use for encrypting/decrypting tokens.",
-            default_factory=Fernet.generate_key,
+            default_factory=derive_fernet_key,
         ),
     ]  # noqa: call-arg
+
+    config_path: Annotated[
+        Path,
+        Field(
+            description="Directory to store the token.",
+            default_factory=get_config_path,
+        ),
+    ]
 
     KEYCLOAK_ENV: DeploymentEnvironment = DeploymentEnvironment.staging
     KEYCLOAK_REALM: KeycloakRealm = KeycloakRealm.sbo

--- a/src/obi_auth/config.py
+++ b/src/obi_auth/config.py
@@ -8,7 +8,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from obi_auth.exception import ConfigError
 from obi_auth.typedef import DeploymentEnvironment, KeycloakRealm
-from obi_auth.util import derive_fernet_key, get_config_path
+from obi_auth.util import derive_fernet_key, get_config_dir
 
 
 class Settings(BaseSettings):
@@ -30,11 +30,11 @@ class Settings(BaseSettings):
         ),
     ]  # noqa: call-arg
 
-    config_path: Annotated[
+    config_dir: Annotated[
         Path,
         Field(
             description="Directory to store the token.",
-            default_factory=get_config_path,
+            default_factory=get_config_dir,
         ),
     ]
 

--- a/src/obi_auth/flow.py
+++ b/src/obi_auth/flow.py
@@ -8,9 +8,8 @@ import re
 import urllib.parse
 import webbrowser
 
-import httpx
-
 from obi_auth.config import settings
+from obi_auth.request import exchange_code_for_token
 from obi_auth.server import AuthServer
 from obi_auth.typedef import DeploymentEnvironment
 
@@ -62,21 +61,13 @@ def _authorize(
 def _exchange_code_for_token(
     code: str, redirect_uri: str, code_verifier: str, override_env: DeploymentEnvironment | None
 ) -> str:
-    response = httpx.post(
-        url=settings.get_keycloak_token_endpoint(override_env=override_env),
-        data={
-            "grant_type": "authorization_code",
-            "code": code,
-            "client_id": settings.KEYCLOAK_CLIENT_ID,
-            "redirect_uri": redirect_uri,
-            "code_verifier": code_verifier,
-        },
+    response = exchange_code_for_token(
+        code=code,
+        redirect_uri=redirect_uri,
+        code_verifier=code_verifier,
+        override_env=override_env,
     )
-    response.raise_for_status()
-
-    access_token = response.json()["access_token"]
-
-    return access_token
+    return response.json()["access_token"]
 
 
 def pkce_authenticate(

--- a/src/obi_auth/request.py
+++ b/src/obi_auth/request.py
@@ -1,0 +1,29 @@
+"""Requests module."""
+
+import httpx
+
+from obi_auth.config import settings
+from obi_auth.typedef import DeploymentEnvironment
+
+
+def exchange_code_for_token(
+    *,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+    override_env: DeploymentEnvironment | None = None,
+):
+    """Exhange authentication code for acces token response."""
+    url = settings.get_keycloak_token_endpoint(override_env)
+    response = httpx.post(
+        url=url,
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": settings.KEYCLOAK_CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+        },
+    )
+    response.raise_for_status()
+    return response

--- a/src/obi_auth/server.py
+++ b/src/obi_auth/server.py
@@ -82,7 +82,5 @@ class AuthServer:
         """Wait for code."""
         if self.auth_state.event.wait(timeout):
             self.auth_state.event.clear()
-            if self.auth_state.code is None:
-                raise LocalServerError("There was no code assigned by authentication.")
             return self.auth_state.code
         raise LocalServerError("Timeout waiting for authorization code")

--- a/src/obi_auth/server.py
+++ b/src/obi_auth/server.py
@@ -82,5 +82,7 @@ class AuthServer:
         """Wait for code."""
         if self.auth_state.event.wait(timeout):
             self.auth_state.event.clear()
+            if self.auth_state.code is None:
+                raise LocalServerError("There was no code assigned by authentication.")
             return self.auth_state.code
         raise LocalServerError("Timeout waiting for authorization code")

--- a/src/obi_auth/storage.py
+++ b/src/obi_auth/storage.py
@@ -26,8 +26,10 @@ class Storage:
         self._ensure_file_mode()
         self._file_path.write_text(data.model_dump_json())
 
-    def read(self) -> TokenInfo:
+    def read(self) -> TokenInfo | None:
         """Read token info from file."""
+        if not self.exists():
+            return None
         data = self._file_path.read_bytes()
         return TokenInfo.model_validate_json(data)
 

--- a/src/obi_auth/storage.py
+++ b/src/obi_auth/storage.py
@@ -27,4 +27,4 @@ class Storage:
 
     def exists(self) -> bool:
         """Return True if file does not exist."""
-        return not self.file_path.exists()
+        return self.file_path.exists()

--- a/src/obi_auth/storage.py
+++ b/src/obi_auth/storage.py
@@ -1,0 +1,30 @@
+"""Storage module."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from obi_auth.typedef import TokenInfo
+
+
+@dataclass
+class Storage:
+    """Storage class."""
+
+    file_path: Path
+
+    def write(self, data: TokenInfo):
+        """Write token info to file."""
+        Path(self.file_path).write_text(data.model_dump_json())
+
+    def read(self) -> TokenInfo:
+        """Read token info from file."""
+        data = Path(self.file_path).read_bytes()
+        return TokenInfo.model_validate_json(data)
+
+    def clear(self) -> None:
+        """Delete file."""
+        Path(self.file_path).unlink(missing_ok=True)
+
+    def empty(self) -> bool:
+        """Return True if file does not exist."""
+        return not Path(self.file_path).exists()

--- a/src/obi_auth/storage.py
+++ b/src/obi_auth/storage.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from obi_auth.typedef import TokenInfo
 
+FILE_MODE = 0o600  # user only read/write
+
 
 @dataclass
 class Storage:
@@ -12,9 +14,15 @@ class Storage:
 
     file_path: Path
 
+    def __post_init__(self):
+        """Ensure file paht has correct permissions."""
+        if self.exists():
+            self.file_path.chmod(mode=FILE_MODE)
+
     def write(self, data: TokenInfo):
         """Write token info to file."""
         self.file_path.write_text(data.model_dump_json())
+        self.file_path.chmod(mode=FILE_MODE)
 
     def read(self) -> TokenInfo:
         """Read token info from file."""

--- a/src/obi_auth/storage.py
+++ b/src/obi_auth/storage.py
@@ -25,6 +25,6 @@ class Storage:
         """Delete file."""
         self.file_path.unlink(missing_ok=True)
 
-    def empty(self) -> bool:
+    def exists(self) -> bool:
         """Return True if file does not exist."""
         return not self.file_path.exists()

--- a/src/obi_auth/storage.py
+++ b/src/obi_auth/storage.py
@@ -1,38 +1,46 @@
 """Storage module."""
 
-from dataclasses import dataclass
 from pathlib import Path
 
-from obi_auth.typedef import TokenInfo
+from obi_auth.typedef import DeploymentEnvironment, TokenInfo
 
 FILE_MODE = 0o600  # user only read/write
+DIRECTORY_MODE = 0o700
+ENV_TO_FILE_NAME = {
+    DeploymentEnvironment.staging: "token_staging.json",
+    DeploymentEnvironment.production: "token_production.json",
+}
 
 
-@dataclass
 class Storage:
     """Storage class."""
 
-    file_path: Path
-
-    def __post_init__(self):
-        """Ensure file paht has correct permissions."""
-        if self.exists():
-            self.file_path.chmod(mode=FILE_MODE)
+    def __init__(self, config_dir: Path, environment: DeploymentEnvironment) -> None:
+        """Initialize storage file from config dir and environment flag."""
+        config_dir.mkdir(exist_ok=True, parents=True)
+        config_dir.chmod(mode=DIRECTORY_MODE)
+        self._file_path = config_dir / ENV_TO_FILE_NAME[environment]
 
     def write(self, data: TokenInfo):
         """Write token info to file."""
-        self.file_path.write_text(data.model_dump_json())
-        self.file_path.chmod(mode=FILE_MODE)
+        self._ensure_file_mode()
+        self._file_path.write_text(data.model_dump_json())
 
     def read(self) -> TokenInfo:
         """Read token info from file."""
-        data = self.file_path.read_bytes()
+        data = self._file_path.read_bytes()
         return TokenInfo.model_validate_json(data)
 
     def clear(self) -> None:
         """Delete file."""
-        self.file_path.unlink(missing_ok=True)
+        self._file_path.unlink(missing_ok=True)
 
     def exists(self) -> bool:
         """Return True if file does not exist."""
-        return self.file_path.exists()
+        return self._file_path.exists()
+
+    def _ensure_file_mode(self) -> None:
+        if self.exists():
+            self._file_path.chmod(mode=FILE_MODE)
+        else:
+            self._file_path.touch(mode=FILE_MODE)

--- a/src/obi_auth/storage.py
+++ b/src/obi_auth/storage.py
@@ -7,8 +7,8 @@ from obi_auth.typedef import DeploymentEnvironment, TokenInfo
 FILE_MODE = 0o600  # user only read/write
 DIRECTORY_MODE = 0o700
 ENV_TO_FILE_NAME = {
-    DeploymentEnvironment.staging: "token_staging.json",
-    DeploymentEnvironment.production: "token_production.json",
+    DeploymentEnvironment.staging: "token-staging.json",
+    DeploymentEnvironment.production: "token-production.json",
 }
 
 

--- a/src/obi_auth/storage.py
+++ b/src/obi_auth/storage.py
@@ -14,17 +14,17 @@ class Storage:
 
     def write(self, data: TokenInfo):
         """Write token info to file."""
-        Path(self.file_path).write_text(data.model_dump_json())
+        self.file_path.write_text(data.model_dump_json())
 
     def read(self) -> TokenInfo:
         """Read token info from file."""
-        data = Path(self.file_path).read_bytes()
+        data = self.file_path.read_bytes()
         return TokenInfo.model_validate_json(data)
 
     def clear(self) -> None:
         """Delete file."""
-        Path(self.file_path).unlink(missing_ok=True)
+        self.file_path.unlink(missing_ok=True)
 
     def empty(self) -> bool:
         """Return True if file does not exist."""
-        return not Path(self.file_path).exists()
+        return not self.file_path.exists()

--- a/src/obi_auth/typedef.py
+++ b/src/obi_auth/typedef.py
@@ -2,6 +2,8 @@
 
 from enum import StrEnum
 
+from pydantic import BaseModel
+
 
 class DeploymentEnvironment(StrEnum):
     """Deployment environment."""
@@ -14,3 +16,10 @@ class KeycloakRealm(StrEnum):
     """Keycloak realms."""
 
     sbo = "SBO"
+
+
+class TokenInfo(BaseModel):
+    """Token information."""
+
+    token: bytes
+    ttl: int

--- a/src/obi_auth/util.py
+++ b/src/obi_auth/util.py
@@ -33,10 +33,6 @@ def derive_fernet_key() -> bytes:
     return base64.urlsafe_b64encode(key)  # Fernet requires base64 encoding
 
 
-def get_config_path() -> Path:
+def get_config_dir() -> Path:
     """Get config file path."""
-    file_name = f"{get_machine_salt().hex()}.json"
-    directory = Path.home() / ".config" / "obi-auth"
-    directory.mkdir(exist_ok=True, parents=True)
-    directory.chmod(0o700)
-    return directory / file_name
+    return Path.home() / ".config" / "obi-auth"

--- a/src/obi_auth/util.py
+++ b/src/obi_auth/util.py
@@ -1,0 +1,46 @@
+"""Utilities."""
+
+import base64
+import hashlib
+import platform
+import socket
+import uuid
+from pathlib import Path
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+
+def get_machine_salt():
+    """Get machine specific salt."""
+    mac = uuid.getnode()  # MAC address
+    hostname = socket.gethostname()
+    system = platform.uname().system
+    node = platform.uname().node
+    raw = f"{mac}-{hostname}-{system}-{node}"
+    return hashlib.sha256(raw.encode()).digest()
+
+
+def derive_fernet_key() -> bytes:
+    """Create Fernet key from unique machine salt."""
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        backend=default_backend(),
+        salt=None,  # Optional: use one if you want context separation
+        info=b"machine-specific-fernet-key",  # Application-specific context
+    )
+    key = hkdf.derive(get_machine_salt())
+    return base64.urlsafe_b64encode(key)  # Fernet requires base64 encoding
+
+
+def get_config_path() -> Path:
+    """Get config file path."""
+    file_name = f"{get_machine_salt().hex()}.json"
+    if platform.system() == "Windows":
+        directory = Path.home() / "AppData" / "Roaming" / "obi-auth"
+    else:
+        directory = Path.home() / ".config" / "obi-auth"
+    directory.mkdir(exist_ok=True, parents=True)
+    return directory / file_name

--- a/src/obi_auth/util.py
+++ b/src/obi_auth/util.py
@@ -14,11 +14,10 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 def get_machine_salt():
     """Get machine specific salt."""
-    mac = uuid.getnode()  # MAC address
     hostname = socket.gethostname()
     system = platform.uname().system
     node = platform.uname().node
-    raw = f"{mac}-{hostname}-{system}-{node}"
+    raw = f"{hostname}-{system}-{node}"
     return hashlib.sha256(raw.encode()).digest()
 
 

--- a/src/obi_auth/util.py
+++ b/src/obi_auth/util.py
@@ -42,5 +42,5 @@ def get_config_path() -> Path:
         directory = Path.home() / "AppData" / "Roaming" / "obi-auth"
     else:
         directory = Path.home() / ".config" / "obi-auth"
-    directory.mkdir(exist_ok=True, parents=True)
+    directory.mkdir(mode=0o700, exist_ok=True, parents=True)
     return directory / file_name

--- a/src/obi_auth/util.py
+++ b/src/obi_auth/util.py
@@ -4,7 +4,6 @@ import base64
 import hashlib
 import platform
 import socket
-import uuid
 from pathlib import Path
 
 from cryptography.hazmat.backends import default_backend
@@ -37,9 +36,7 @@ def derive_fernet_key() -> bytes:
 def get_config_path() -> Path:
     """Get config file path."""
     file_name = f"{get_machine_salt().hex()}.json"
-    if platform.system() == "Windows":
-        directory = Path.home() / "AppData" / "Roaming" / "obi-auth"
-    else:
-        directory = Path.home() / ".config" / "obi-auth"
-    directory.mkdir(mode=0o700, exist_ok=True, parents=True)
+    directory = Path.home() / ".config" / "obi-auth"
+    directory.mkdir(exist_ok=True, parents=True)
+    directory.chmod(0o700)
     return directory / file_name

--- a/src/obi_auth/util.py
+++ b/src/obi_auth/util.py
@@ -16,9 +16,7 @@ def get_machine_salt():
     uname = platform.uname()
     network_name = platform.node()
     user = getpass.getuser()
-
     raw = f"{uname.system}-{uname.release}-{uname.version}-{uname.machine}-{network_name}-{user}"
-    print(raw)
     return hashlib.sha256(raw.encode()).digest()
 
 

--- a/src/obi_auth/util.py
+++ b/src/obi_auth/util.py
@@ -17,6 +17,7 @@ def get_machine_salt():
     network_name = platform.node()
     user = getpass.getuser()
     raw = f"{uname.system}-{uname.release}-{uname.version}-{uname.machine}-{network_name}-{user}"
+    print(raw)
     return hashlib.sha256(raw.encode()).digest()
 
 

--- a/src/obi_auth/util.py
+++ b/src/obi_auth/util.py
@@ -17,7 +17,6 @@ def get_machine_salt():
     network_name = platform.node()
     user = getpass.getuser()
     raw = f"{uname.system}-{uname.release}-{uname.version}-{uname.machine}-{network_name}-{user}"
-    print(raw)
     return hashlib.sha256(raw.encode()).digest()
 
 

--- a/src/obi_auth/util.py
+++ b/src/obi_auth/util.py
@@ -1,9 +1,9 @@
 """Utilities."""
 
 import base64
+import getpass
 import hashlib
 import platform
-import socket
 from pathlib import Path
 
 from cryptography.hazmat.backends import default_backend
@@ -13,10 +13,12 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 def get_machine_salt():
     """Get machine specific salt."""
-    hostname = socket.gethostname()
-    system = platform.uname().system
-    node = platform.uname().node
-    raw = f"{hostname}-{system}-{node}"
+    uname = platform.uname()
+    network_name = platform.node()
+    user = getpass.getuser()
+
+    raw = f"{uname.system}-{uname.release}-{uname.version}-{uname.machine}-{network_name}-{user}"
+    print(raw)
     return hashlib.sha256(raw.encode()).digest()
 
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -45,7 +45,7 @@ def test_token_cache(token):
     cache = test_module.TokenCache(storage=storage)
 
     # if no stored token get returns None
-    storage.empty.return_value = True
+    storage.exists.return_value = True
     assert cache.get() is None
 
     # set a valid token
@@ -55,7 +55,7 @@ def test_token_cache(token):
     (token_info,), _ = storage.write.call_args
 
     # get the valid token
-    storage.empty.return_value = False
+    storage.exists.return_value = False
     storage.read.return_value = token_info
 
     # fetch and decrypt the token
@@ -70,7 +70,7 @@ def test_token_cache__expired(token_expired):
 
     (token_info,), _ = storage.write.call_args
 
-    storage.empty.return_value = False
+    storage.exists.return_value = False
     storage.read.return_value = token_info
 
     res = cache.get()

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -45,7 +45,7 @@ def test_token_cache(token):
     cache = test_module.TokenCache(storage=storage)
 
     # if no stored token get returns None
-    storage.exists.return_value = True
+    storage.exists.return_value = False
     assert cache.get() is None
 
     # set a valid token
@@ -55,7 +55,7 @@ def test_token_cache(token):
     (token_info,), _ = storage.write.call_args
 
     # get the valid token
-    storage.exists.return_value = False
+    storage.exists.return_value = True
     storage.read.return_value = token_info
 
     # fetch and decrypt the token
@@ -70,7 +70,7 @@ def test_token_cache__expired(token_expired):
 
     (token_info,), _ = storage.write.call_args
 
-    storage.exists.return_value = False
+    storage.exists.return_value = True
     storage.read.return_value = token_info
 
     res = cache.get()

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -6,8 +6,10 @@ from cryptography.fernet import Fernet
 
 from obi_auth import cache as test_module
 from obi_auth.config import settings
+from obi_auth.util import derive_fernet_key
 
-CIPHER = Fernet(key=settings.secret_key)
+
+CIPHER = Fernet(key=derive_fernet_key())
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -5,9 +5,7 @@ import pytest
 from cryptography.fernet import Fernet
 
 from obi_auth import cache as test_module
-from obi_auth.config import settings
 from obi_auth.util import derive_fernet_key
-
 
 CIPHER = Fernet(key=derive_fernet_key())
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,0 +1,78 @@
+from unittest.mock import Mock
+
+import jwt
+import pytest
+from cryptography.fernet import Fernet
+
+from obi_auth import cache as test_module
+from obi_auth.config import settings
+
+CIPHER = Fernet(key=settings.secret_key)
+
+
+@pytest.fixture(scope="module")
+def issued_at():
+    return test_module._now()
+
+
+@pytest.fixture(scope="module")
+def expires_at(issued_at):
+    return issued_at + 3600
+
+
+@pytest.fixture(scope="module")
+def token_decoded(issued_at, expires_at):
+    return {
+        "exp": expires_at,
+        "iat": issued_at,
+    }
+
+
+@pytest.fixture(scope="module")
+def token(token_decoded):
+    return jwt.encode(token_decoded, key=None, algorithm="none")
+
+
+@pytest.fixture
+def token_expired(token_decoded):
+    data = token_decoded.copy()
+    data["exp"] = test_module._now() - 1
+    return jwt.encode(data, key=None, algorithm="none")
+
+
+def test_token_cache(token):
+    storage = Mock()
+    cache = test_module.TokenCache(storage=storage)
+
+    # if no stored token get returns None
+    storage.empty.return_value = True
+    assert cache.get() is None
+
+    # set a valid token
+    cache.set(token)
+
+    # grab the stored token from the mock
+    (token_info,), _ = storage.write.call_args
+
+    # get the valid token
+    storage.empty.return_value = False
+    storage.read.return_value = token_info
+
+    # fetch and decrypt the token
+    res = cache.get()
+    assert res == token
+
+
+def test_token_cache__expired(token_expired):
+    storage = Mock()
+    cache = test_module.TokenCache(storage=storage)
+    cache.set(token_expired)
+
+    (token_info,), _ = storage.write.call_args
+
+    storage.empty.return_value = False
+    storage.read.return_value = token_info
+
+    res = cache.get()
+    assert res is None
+    storage.clear.assert_called_once()

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -42,37 +42,36 @@ def token_expired(token_decoded):
 
 def test_token_cache(token):
     storage = Mock()
-    cache = test_module.TokenCache(storage=storage)
+    cache = test_module.TokenCache()
 
     # if no stored token get returns None
-    storage.exists.return_value = False
-    assert cache.get() is None
+    storage.read.return_value = None
+    assert cache.get(storage) is None
 
     # set a valid token
-    cache.set(token)
+    cache.set(token, storage)
 
     # grab the stored token from the mock
     (token_info,), _ = storage.write.call_args
 
     # get the valid token
-    storage.exists.return_value = True
     storage.read.return_value = token_info
 
     # fetch and decrypt the token
-    res = cache.get()
+    res = cache.get(storage)
     assert res == token
 
 
 def test_token_cache__expired(token_expired):
     storage = Mock()
-    cache = test_module.TokenCache(storage=storage)
-    cache.set(token_expired)
+    cache = test_module.TokenCache()
+    cache.set(token_expired, storage)
 
     (token_info,), _ = storage.write.call_args
 
     storage.exists.return_value = True
     storage.read.return_value = token_info
 
-    res = cache.get()
+    res = cache.get(storage)
     assert res is None
     storage.clear.assert_called_once()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -8,7 +8,13 @@ from obi_auth import exception
 
 @patch("obi_auth.flow.webbrowser")
 @patch("obi_auth.client.AuthServer")
-def test_get_token(mock_server, mock_web, httpx_mock):
+@patch("obi_auth.client._TOKEN_CACHE")
+def test_get_token(mock_cache, mock_server, mock_web, httpx_mock):
+    mock_cache.get.return_value = "foo"
+    assert test_module.get_token() == "foo"
+
+    mock_cache.get.return_value = None
+
     httpx_mock.add_response(method="POST", json={"access_token": "mock-token"})
 
     mock_local = Mock()

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,0 +1,52 @@
+import pytest
+
+from obi_auth import storage as test_module
+from obi_auth.typedef import TokenInfo
+
+
+@pytest.fixture
+def path(tmp_path):
+    return tmp_path / "foo.json"
+
+
+def test_storage__empty(path):
+    storage = test_module.Storage(path)
+    assert storage.empty()
+    path.write_text("foo")
+    assert not storage.empty()
+
+
+def test_storage__read(path):
+    obj = TokenInfo(token=b"foo", ttl=100)
+    path.write_text(obj.model_dump_json())
+
+    res = test_module.Storage(path).read()
+    assert res == obj
+
+
+def test_storage__write(path):
+    storage = test_module.Storage(path)
+    obj = TokenInfo(token=b"foo", ttl=100)
+    storage.write(obj)
+    res = TokenInfo.model_validate_json(path.read_bytes())
+    assert res == obj
+
+    obj2 = TokenInfo(token=b"bar", ttl=100)
+    storage.write(obj2)
+    res = TokenInfo.model_validate_json(path.read_bytes())
+    assert res == obj2
+
+
+def test_storage__clear(path):
+    path.write_text("foo")
+    assert path.exists()
+
+    storage = test_module.Storage(path)
+
+    storage.clear()
+
+    assert not path.exists()
+    assert storage.empty()
+
+    # nothing should happen
+    storage.clear()

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -11,9 +11,9 @@ def path(tmp_path):
 
 def test_storage__empty(path):
     storage = test_module.Storage(path)
-    assert storage.empty()
+    assert storage.exists()
     path.write_text("foo")
-    assert not storage.empty()
+    assert not storage.exists()
 
 
 def test_storage__read(path):
@@ -46,7 +46,7 @@ def test_storage__clear(path):
     storage.clear()
 
     assert not path.exists()
-    assert storage.empty()
+    assert storage.exists()
 
     # nothing should happen
     storage.clear()

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -11,9 +11,9 @@ def path(tmp_path):
 
 def test_storage__empty(path):
     storage = test_module.Storage(path)
-    assert storage.exists()
-    path.write_text("foo")
     assert not storage.exists()
+    path.write_text("foo")
+    assert storage.exists()
 
 
 def test_storage__read(path):
@@ -46,7 +46,7 @@ def test_storage__clear(path):
     storage.clear()
 
     assert not path.exists()
-    assert storage.exists()
+    assert not storage.exists()
 
     # nothing should happen
     storage.clear()

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,7 +1,14 @@
+import os
+import stat
+
 import pytest
 
 from obi_auth import storage as test_module
 from obi_auth.typedef import TokenInfo
+
+
+def get_unix_permissions(path):
+    return stat.S_IMODE(os.lstat(path).st_mode)
 
 
 @pytest.fixture
@@ -50,3 +57,20 @@ def test_storage__clear(path):
 
     # nothing should happen
     storage.clear()
+
+
+def test_file_permissions(tmp_path):
+    existing = tmp_path / "foo.json"
+    existing.touch()
+    existing.chmod(mode=0o777)
+    assert get_unix_permissions(existing) == 0o777
+
+    storage = test_module.Storage(existing)
+    assert get_unix_permissions(storage.file_path) == 0o600
+
+    storage.write(TokenInfo(token=b"bar", ttl=100))
+    assert get_unix_permissions(storage.file_path) == 0o600
+
+    storage.clear()
+    storage.write(TokenInfo(token=b"bar", ttl=100))
+    assert get_unix_permissions(storage.file_path) == 0o600

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -4,7 +4,10 @@ import stat
 import pytest
 
 from obi_auth import storage as test_module
-from obi_auth.typedef import TokenInfo
+from obi_auth.typedef import DeploymentEnvironment, TokenInfo
+
+PROD = DeploymentEnvironment.production
+STAGING = DeploymentEnvironment.staging
 
 
 def get_unix_permissions(path):
@@ -12,65 +15,111 @@ def get_unix_permissions(path):
 
 
 @pytest.fixture
-def path(tmp_path):
-    return tmp_path / "foo.json"
+def config_dir(tmp_path):
+    return tmp_path / "dir"
 
 
-def test_storage__empty(path):
-    storage = test_module.Storage(path)
+def test_storage_init__no_dir(config_dir):
+    assert not config_dir.exists()
+
+    test_module.Storage(config_dir, STAGING)
+    assert config_dir.exists()
+
+    # check that directory created with correct permissions
+    assert get_unix_permissions(config_dir) == 0o700
+
+    test_module.Storage(config_dir, PROD)
+    assert config_dir.exists()
+
+    # check that directory created with correct permissions
+    assert get_unix_permissions(config_dir) == 0o700
+
+
+def test_storage_init__existing_dir(config_dir):
+    config_dir.mkdir()
+
+    assert get_unix_permissions(config_dir) != 0o700
+
+    storage = test_module.Storage(config_dir, "staging")
+    assert config_dir.exists()
+
+    assert get_unix_permissions(config_dir) == 0o700
+
+    expected_file = config_dir / "token_staging.json"
+    assert storage._file_path == expected_file
+
+    # not written yet
     assert not storage.exists()
-    path.write_text("foo")
+
+
+def test_storage__empty(config_dir):
+    storage = test_module.Storage(config_dir, STAGING)
+    assert not storage.exists()
+    storage._file_path.write_text("foo")
     assert storage.exists()
 
 
-def test_storage__read(path):
+def test_storage__read(config_dir):
     obj = TokenInfo(token=b"foo", ttl=100)
-    path.write_text(obj.model_dump_json())
 
-    res = test_module.Storage(path).read()
+    storage = test_module.Storage(config_dir, STAGING)
+
+    res = storage.read()
+    assert res is None
+
+    storage._file_path.write_text(obj.model_dump_json())
+
+    res = storage.read()
     assert res == obj
 
+    storage2 = test_module.Storage(config_dir, STAGING)
+    res = storage2.read()
+    assert res == obj
 
-def test_storage__write(path):
-    storage = test_module.Storage(path)
+    storage3 = test_module.Storage(config_dir, PROD)
+    assert not storage3.exists()
+
+
+def test_storage__write(config_dir):
+    storage = test_module.Storage(config_dir, PROD)
     obj = TokenInfo(token=b"foo", ttl=100)
     storage.write(obj)
-    res = TokenInfo.model_validate_json(path.read_bytes())
+    res = TokenInfo.model_validate_json(storage._file_path.read_bytes())
     assert res == obj
 
     obj2 = TokenInfo(token=b"bar", ttl=100)
     storage.write(obj2)
-    res = TokenInfo.model_validate_json(path.read_bytes())
+    res = TokenInfo.model_validate_json(storage._file_path.read_bytes())
     assert res == obj2
 
 
-def test_storage__clear(path):
-    path.write_text("foo")
-    assert path.exists()
+def test_storage__clear(config_dir):
+    storage = test_module.Storage(config_dir, PROD)
 
-    storage = test_module.Storage(path)
+    storage._file_path.write_text("foo")
+    assert storage.exists()
 
     storage.clear()
 
-    assert not path.exists()
+    assert not storage._file_path.exists()
     assert not storage.exists()
 
     # nothing should happen
     storage.clear()
 
 
-def test_file_permissions(tmp_path):
-    existing = tmp_path / "foo.json"
+def test_file_permissions(config_dir):
+    existing = test_module.Storage(config_dir, STAGING)._file_path
     existing.touch()
     existing.chmod(mode=0o777)
     assert get_unix_permissions(existing) == 0o777
 
-    storage = test_module.Storage(existing)
-    assert get_unix_permissions(storage.file_path) == 0o600
+    storage = test_module.Storage(config_dir, STAGING)
+    assert get_unix_permissions(storage._file_path) != 0o600
 
     storage.write(TokenInfo(token=b"bar", ttl=100))
-    assert get_unix_permissions(storage.file_path) == 0o600
+    assert get_unix_permissions(storage._file_path) == 0o600
 
     storage.clear()
     storage.write(TokenInfo(token=b"bar", ttl=100))
-    assert get_unix_permissions(storage.file_path) == 0o600
+    assert get_unix_permissions(storage._file_path) == 0o600

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -4,6 +4,7 @@ import stat
 import pytest
 
 from obi_auth import storage as test_module
+from obi_auth.storage import ENV_TO_FILE_NAME
 from obi_auth.typedef import DeploymentEnvironment, TokenInfo
 
 PROD = DeploymentEnvironment.production
@@ -45,7 +46,7 @@ def test_storage_init__existing_dir(config_dir):
 
     assert get_unix_permissions(config_dir) == 0o700
 
-    expected_file = config_dir / "token_staging.json"
+    expected_file = config_dir / ENV_TO_FILE_NAME[STAGING]
     assert storage._file_path == expected_file
 
     # not written yet

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from obi_auth import util as test_module
+
+
+@patch("obi_auth.util.platform")
+@patch("pathlib.Path.home")
+@patch("obi_auth.util.get_machine_salt")
+def test_get_config_path(mock_salt, mock_home, mock_platform, tmp_path):
+    mock_home.return_value = Path(tmp_path)
+    mock_salt.return_value = Mock(hex=Mock(return_value="foo"))
+
+    mock_platform.system.return_value = "Windows"
+    res = test_module.get_config_path()
+    assert res == Path(f"{tmp_path}/AppData/Roaming/obi-auth/foo.json")
+    assert res.parent.exists()
+
+    mock_platform.system.return_value = "Linux"
+    res = test_module.get_config_path()
+    assert res == Path(f"{tmp_path}/.config/obi-auth/foo.json")
+    assert res.parent.exists()

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,29 +1,17 @@
-import os
-import stat
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from obi_auth import util as test_module
 
 
+def test_machine_salt():
+    res1 = test_module.get_machine_salt()
+    res2 = test_module.get_machine_salt()
+    assert res1 == res2
+
+
 @patch("pathlib.Path.home")
-@patch("obi_auth.util.get_machine_salt")
-def test_get_config_path(mock_salt, mock_home, tmp_path):
-    directory = Path(tmp_path)
-    mock_home.return_value = directory
-    mock_salt.return_value = Mock(hex=Mock(return_value="foo"))
-
-    expected_dir = Path(f"{tmp_path}/.config/obi-auth")
-
-    res = test_module.get_config_path()
-    assert res == expected_dir / "foo.json"
-    assert res.parent.exists()
-
-    # check that directory create with correct permissions
-    assert stat.S_IMODE(os.lstat(expected_dir).st_mode) == 0o700
-
-    # check that the permissions for an existing dir will change
-    expected_dir.chmod(0o777)
-    assert stat.S_IMODE(os.lstat(expected_dir).st_mode) == 0o777
-    test_module.get_config_path()
-    assert stat.S_IMODE(os.lstat(expected_dir).st_mode) == 0o700
+def test_get_config_dir(mock_home):
+    mock_home.return_value = Path("/foo")
+    res = test_module.get_config_dir()
+    assert res == Path("/foo/.config/obi-auth")

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,22 +1,29 @@
+import os
+import stat
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 from obi_auth import util as test_module
 
 
-@patch("obi_auth.util.platform")
 @patch("pathlib.Path.home")
 @patch("obi_auth.util.get_machine_salt")
-def test_get_config_path(mock_salt, mock_home, mock_platform, tmp_path):
-    mock_home.return_value = Path(tmp_path)
+def test_get_config_path(mock_salt, mock_home, tmp_path):
+    directory = Path(tmp_path)
+    mock_home.return_value = directory
     mock_salt.return_value = Mock(hex=Mock(return_value="foo"))
 
-    mock_platform.system.return_value = "Windows"
+    expected_dir = Path(f"{tmp_path}/.config/obi-auth")
+
     res = test_module.get_config_path()
-    assert res == Path(f"{tmp_path}/AppData/Roaming/obi-auth/foo.json")
+    assert res == expected_dir / "foo.json"
     assert res.parent.exists()
 
-    mock_platform.system.return_value = "Linux"
-    res = test_module.get_config_path()
-    assert res == Path(f"{tmp_path}/.config/obi-auth/foo.json")
-    assert res.parent.exists()
+    # check that directory create with correct permissions
+    assert stat.S_IMODE(os.lstat(expected_dir).st_mode) == 0o700
+
+    # check that the permissions for an existing dir will change
+    expected_dir.chmod(0o777)
+    assert stat.S_IMODE(os.lstat(expected_dir).st_mode) == 0o777
+    test_module.get_config_path()
+    assert stat.S_IMODE(os.lstat(expected_dir).st_mode) == 0o700


### PR DESCRIPTION
A different approach to avoid redirecting is to reuse the token for as long as it lives.