### PR TITLE
Fix production keycloak URL

### DIFF
--- a/src/obi_auth/config.py
+++ b/src/obi_auth/config.py
@@ -42,7 +42,7 @@ class Settings(BaseSettings):
             case DeploymentEnvironment.staging:
                 return f"https://staging.openbraininstitute.org/auth/realms/{self.KEYCLOAK_REALM}"
             case DeploymentEnvironment.production:
-                return f"https://openbraininstitute.org/auth/realms/{self.KEYCLOAK_REALM}"
+                return f"https://www.openbraininstitute.org/auth/realms/{self.KEYCLOAK_REALM}"
         raise ConfigError(f"Unknown deployment environment {env}")
 
     def get_keycloak_token_endpoint(self, override_env: DeploymentEnvironment | None = None) -> str:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -19,7 +19,7 @@ def test_get_keycloak_url(settings):
     assert res == "https://staging.openbraininstitute.org/auth/realms/SBO"
 
     res = settings.get_keycloak_url(override_env="production")
-    assert res == "https://openbraininstitute.org/auth/realms/SBO"
+    assert res == "https://www.openbraininstitute.org/auth/realms/SBO"
 
     with pytest.raises(exception.ConfigError, match="Unknown deployment environment foo"):
         settings.get_keycloak_url(override_env="foo")
@@ -39,7 +39,7 @@ def test_get_keycloak_token_endpoint(settings):
     )
 
     res = settings.get_keycloak_token_endpoint(override_env="production")
-    assert res == "https://openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/token"
+    assert res == "https://www.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/token"
 
 
 def test_get_keycloak_auth_endpoint(settings):
@@ -54,4 +54,4 @@ def test_get_keycloak_auth_endpoint(settings):
     )
 
     res = settings.get_keycloak_auth_endpoint(override_env="production")
-    assert res == "https://openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth"
+    assert res == "https://www.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth"


### PR DESCRIPTION
I was getting this error when getting a token for prod:
```
>>> from obi_auth import get_token
... get_token(environment="production")
...
Traceback (most recent call last):
  File "<python-input-5>", line 2, in <module>
    get_token(environment="production")
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/danielfr/obi/venvs/myenv/lib/python3.13/site-packages/obi_auth/client.py", line 17, in get_token
    return pkce_authenticate(server=local_server, override_env=environment)
  File "/Users/danielfr/obi/venvs/myenv/lib/python3.13/site-packages/obi_auth/flow.py", line 88, in pkce_authenticate
    access_token = _exchange_code_for_token(code, server.redirect_uri, code_verifier, override_env)
  File "/Users/danielfr/obi/venvs/myenv/lib/python3.13/site-packages/obi_auth/flow.py", line 75, in _exchange_code_for_token
    response.raise_for_status()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/danielfr/obi/venvs/myenv/lib/python3.13/site-packages/httpx/_models.py", line 829, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Redirect response '302 Moved Temporarily' for url 'https://openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/token'
Redirect location: 'https://www.openbraininstitute.org:443/auth/realms/SBO/protocol/openid-connect/token'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302
```