### PR TITLE
Use an effective token ttl for refreshing

### DIFF
--- a/src/obi_auth/cache.py
+++ b/src/obi_auth/cache.py
@@ -5,6 +5,7 @@ import time
 import jwt
 from cryptography.fernet import Fernet, InvalidToken
 
+from obi_auth.config import settings
 from obi_auth.storage import Storage
 from obi_auth.typedef import TokenInfo
 from obi_auth.util import derive_fernet_key
@@ -55,4 +56,5 @@ def _now() -> int:
 def _get_token_times(token: str) -> tuple[int, int]:
     """Get the creation time and time to live of a token."""
     info = jwt.decode(token.encode(), options={"verify_signature": False})
-    return info["iat"], info["exp"] - info["iat"]
+    effective_ttl = info["exp"] - info["iat"] - settings.EPSILON_TOKEN_TTL_SECONDS
+    return info["iat"], effective_ttl

--- a/src/obi_auth/config.py
+++ b/src/obi_auth/config.py
@@ -34,6 +34,8 @@ class Settings(BaseSettings):
     KEYCLOAK_REALM: KeycloakRealm = KeycloakRealm.sbo
     KEYCLOAK_CLIENT_ID: str = "obi-entitysdk-auth"
 
+    EPSILON_TOKEN_TTL_SECONDS: int = 60
+
     LOCAL_SERVER_TIMEOUT: int = 60
 
     def get_keycloak_url(self, override_env: DeploymentEnvironment | None = None):


### PR DESCRIPTION
Add an epsilon of 60s when checking for token expiration to ensure that the token used is always valid.

Otherwise, it could be possible that obi-auth considers the token valid, but by the time it reaches the server has expired.