### PR TITLE
Teach using refresh tokens

### DIFF
--- a/src/obi_auth/cache.py
+++ b/src/obi_auth/cache.py
@@ -1,13 +1,44 @@
 """Token cache module."""
 
+import json
+import logging
 import time
 
+import httpx
 import jwt
 from cryptography.fernet import Fernet, InvalidToken
 
+from obi_auth.config import settings
 from obi_auth.storage import Storage
 from obi_auth.typedef import TokenInfo
 from obi_auth.util import derive_fernet_key
+
+L = logging.getLogger(__name__)
+
+
+def _get_access_token(token: dict) -> dict | None:
+    L.debug("Trying to use cached token")
+
+    creation_time, time_to_live = _get_refresh_times(token["access_token"])
+    if creation_time + time_to_live > int(time.time()):
+        L.debug("`access_token` is still valid, returning it")
+        return token
+
+    creation_time, time_to_live = _get_refresh_times(token["refresh_token"])
+    if creation_time + time_to_live > int(time.time()):
+        L.debug("`refresh_token` is still valid, try to get a new refresh and access token")
+        url = settings.get_keycloak_token_endpoint()
+        resp = httpx.post(
+            url,
+            data={
+                "grant_type": "refresh_token",
+                "client_id": settings.KEYCLOAK_CLIENT_ID,
+                "refresh_token": token["refresh_token"],
+            },
+        )
+        return resp.json()
+
+    return None
 
 
 class TokenCache:
@@ -19,25 +50,31 @@ class TokenCache:
         """Initialize the token cache."""
         self._cipher = Fernet(key=derive_fernet_key())
 
-    def get(self, storage: Storage) -> str | None:
+    def get(self, storage: Storage) -> dict | None:
         """Get a cached token if valid, else None."""
         if not (token_info := storage.read()):
             return None
         try:
-            return self._cipher.decrypt_at_time(
-                token=token_info.token,
-                ttl=token_info.ttl,
-                current_time=_now(),
-            ).decode()
+            token = json.loads(
+                self._cipher.decrypt_at_time(
+                    token=token_info.token,
+                    ttl=token_info.ttl,
+                    current_time=_now(),
+                ).decode()
+            )
+            token = _get_access_token(token)
+            if token is not None:
+                self.set(token, storage)
+            return token
         except InvalidToken:
             storage.clear()
             return None
 
-    def set(self, token: str, storage: Storage) -> None:
+    def set(self, token: dict, storage: Storage) -> None:
         """Store a new token in the cache."""
-        creation_time, time_to_live = _get_token_times(token)
+        creation_time, time_to_live = _get_refresh_times(token["refresh_token"])
         fernet_token: bytes = self._cipher.encrypt_at_time(
-            data=token.encode(encoding="utf-8"),
+            data=json.dumps(token).encode(encoding="utf-8"),
             current_time=creation_time,
         )
         token_info = TokenInfo(
@@ -52,7 +89,7 @@ def _now() -> int:
     return int(time.time())
 
 
-def _get_token_times(token: str) -> tuple[int, int]:
+def _get_refresh_times(token: str) -> tuple[int, int]:
     """Get the creation time and time to live of a token."""
     info = jwt.decode(token.encode(), options={"verify_signature": False})
     return info["iat"], info["exp"] - info["iat"]

--- a/src/obi_auth/cache.py
+++ b/src/obi_auth/cache.py
@@ -36,7 +36,8 @@ def _get_access_token(token: dict) -> dict | None:
                 "refresh_token": token["refresh_token"],
             },
         )
-        return resp.json()
+        if resp.is_success:
+            return resp.json()
 
     return None
 

--- a/src/obi_auth/client.py
+++ b/src/obi_auth/client.py
@@ -32,7 +32,7 @@ def get_token(
 
     if token := _TOKEN_CACHE.get(storage):
         L.debug("Using cached token")
-        return token
+        return token["access_token"]
 
     auth_method = _get_auth_method(auth_mode)
 
@@ -40,7 +40,7 @@ def get_token(
 
     _TOKEN_CACHE.set(token, storage)
 
-    return token
+    return token["access_token"]
 
 
 def _get_auth_method(auth_mode: AuthMode) -> Callable:

--- a/src/obi_auth/flows/daf.py
+++ b/src/obi_auth/flows/daf.py
@@ -59,5 +59,4 @@ def _get_device_code_token(
     if response.status_code == 400 and response.json()["error"] == "authorization_pending":
         return None
     response.raise_for_status()
-    data = response.json()
-    return data["access_token"]
+    return response.json()

--- a/src/obi_auth/flows/pkce.py
+++ b/src/obi_auth/flows/pkce.py
@@ -67,7 +67,7 @@ def _exchange_code_for_token(
         code_verifier=code_verifier,
         override_env=override_env,
     )
-    return response.json()["access_token"]
+    return response.json()
 
 
 def pkce_authenticate(
@@ -76,5 +76,5 @@ def pkce_authenticate(
     """Get access token using the PCKE authentication flow."""
     code_verifier, code_challenge = _generate_pkce_pair()
     code = _authorize(server, code_challenge, environment)
-    access_token = _exchange_code_for_token(code, server.redirect_uri, code_verifier, environment)
-    return access_token
+    token = _exchange_code_for_token(code, server.redirect_uri, code_verifier, environment)
+    return token

--- a/tests/unit/flows/test_pkce.py
+++ b/tests/unit/flows/test_pkce.py
@@ -22,14 +22,15 @@ def test_build_auth_url():
 
 
 def test_exchange_code_for_token(httpx_mock):
-    httpx_mock.add_response(method="POST", json={"access_token": "mock-token"})
+    mock_resp = {"access_token": "mock-token"}
+    httpx_mock.add_response(method="POST", json=mock_resp)
     res = test_module._exchange_code_for_token(
         code="mock-code",
         redirect_uri="mock-uri",
         code_verifier="mock-verifier",
         override_env=None,
     )
-    assert res == "mock-token"
+    assert res == mock_resp
 
 
 @patch("obi_auth.flows.pkce.webbrowser")


### PR DESCRIPTION
* by default, keycloak returns a `refresh_token` with a longer lifetime than the `access_token`.
* We now store the refresh token, so we don't have to re-authenticate as often