### PR TITLE
Use new domain url for staging/prod

### DIFF
--- a/src/obi_auth/config.py
+++ b/src/obi_auth/config.py
@@ -44,7 +44,7 @@ class Settings(BaseSettings):
             case DeploymentEnvironment.staging:
                 return "https://staging.cell-a.openbraininstitute.org"
             case DeploymentEnvironment.production:
-                return "https://www.openbraininstitute.org"
+                return "https://cell-a.openbraininstitute.org"
             case _:
                 raise ConfigError(f"Unknown deployment environment {env}")
 

--- a/src/obi_auth/config.py
+++ b/src/obi_auth/config.py
@@ -38,14 +38,20 @@ class Settings(BaseSettings):
 
     LOCAL_SERVER_TIMEOUT: int = 60
 
-    def get_keycloak_url(self, override_env: DeploymentEnvironment | None = None):
-        """Return keycloak url."""
+    def _get_domain_url(self, override_env: DeploymentEnvironment) -> str:
+        """Return domain url based on environment."""
         match env := override_env or self.KEYCLOAK_ENV:
             case DeploymentEnvironment.staging:
-                return f"https://staging.openbraininstitute.org/auth/realms/{self.KEYCLOAK_REALM}"
+                return "https://staging.cell-a.openbraininstitute.org"
             case DeploymentEnvironment.production:
-                return f"https://www.openbraininstitute.org/auth/realms/{self.KEYCLOAK_REALM}"
-        raise ConfigError(f"Unknown deployment environment {env}")
+                return "https://www.openbraininstitute.org"
+            case _:
+                raise ConfigError(f"Unknown deployment environment {env}")
+
+    def get_keycloak_url(self, override_env: DeploymentEnvironment | None = None):
+        """Return keycloak url."""
+        url = self._get_domain_url(override_env)
+        return f"{url}/auth/realms/{self.KEYCLOAK_REALM}"
 
     def get_keycloak_token_endpoint(self, override_env: DeploymentEnvironment | None = None) -> str:
         """Return keycloak token endpoint."""
@@ -73,13 +79,8 @@ class Settings(BaseSettings):
 
     def get_auth_manager_url(self, override_env: DeploymentEnvironment | None = None) -> str:
         """Return auth manager url."""
-        match env := override_env or self.KEYCLOAK_ENV:
-            case DeploymentEnvironment.staging:
-                return "https://staging.openbraininstitute.org/api/auth-manager/v1"
-            case DeploymentEnvironment.production:
-                return "https://www.openbraininstitute.org/api/auth-manager/v1"
-            case _:
-                raise ConfigError(f"Unknown deployment environment {env}")
+        url = self._get_domain_url(override_env)
+        return f"{url}/api/auth-manager/v1"
 
     def get_auth_manager_access_token_endpoint(
         self, override_env: DeploymentEnvironment | None = None

--- a/src/obi_auth/config.py
+++ b/src/obi_auth/config.py
@@ -50,7 +50,7 @@ class Settings(BaseSettings):
 
     def get_keycloak_url(self, override_env: DeploymentEnvironment | None = None):
         """Return keycloak url."""
-        url = self._get_domain_url(override_env)
+        url = self._get_domain_url(override_env or self.KEYCLOAK_ENV)
         return f"{url}/auth/realms/{self.KEYCLOAK_REALM}"
 
     def get_keycloak_token_endpoint(self, override_env: DeploymentEnvironment | None = None) -> str:
@@ -79,7 +79,7 @@ class Settings(BaseSettings):
 
     def get_auth_manager_url(self, override_env: DeploymentEnvironment | None = None) -> str:
         """Return auth manager url."""
-        url = self._get_domain_url(override_env)
+        url = self._get_domain_url(override_env or self.KEYCLOAK_ENV)
         return f"{url}/api/auth-manager/v1"
 
     def get_auth_manager_access_token_endpoint(

--- a/tests/unit/flows/test_pkce.py
+++ b/tests/unit/flows/test_pkce.py
@@ -10,7 +10,7 @@ def test_build_auth_url():
         override_env=None,
     )
     assert res == (
-        "https://staging.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth"
+        "https://staging.cell-a.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth"
         "?response_type=code"
         "&client_id=obi-entitysdk-auth"
         "&redirect_uri=bar"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,15 +3,15 @@ import pytest
 from obi_auth import exception
 
 PROD_OBI_URL = "https://www.openbraininstitute.org"
-STAGING_OBI_URL = "https://staging.openbraininstitute.org"
+STAGING_OBI_URL = "https://staging.cell-a.openbraininstitute.org"
 
 
 def test_get_keycloak_url(settings):
     res = settings.get_keycloak_url()
-    assert res == "https://staging.openbraininstitute.org/auth/realms/SBO"
+    assert res == "https://staging.cell-a.openbraininstitute.org/auth/realms/SBO"
 
     res = settings.get_keycloak_url(override_env="staging")
-    assert res == "https://staging.openbraininstitute.org/auth/realms/SBO"
+    assert res == "https://staging.cell-a.openbraininstitute.org/auth/realms/SBO"
 
     res = settings.get_keycloak_url(override_env="production")
     assert res == "https://www.openbraininstitute.org/auth/realms/SBO"
@@ -24,13 +24,13 @@ def test_get_keycloak_token_endpoint(settings):
     res = settings.get_keycloak_token_endpoint()
     assert (
         res
-        == "https://staging.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/token"
+        == "https://staging.cell-a.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/token"
     )
 
     res = settings.get_keycloak_token_endpoint(override_env="staging")
     assert (
         res
-        == "https://staging.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/token"
+        == "https://staging.cell-a.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/token"
     )
 
     res = settings.get_keycloak_token_endpoint(override_env="production")
@@ -40,12 +40,14 @@ def test_get_keycloak_token_endpoint(settings):
 def test_get_keycloak_auth_endpoint(settings):
     res = settings.get_keycloak_auth_endpoint()
     assert (
-        res == "https://staging.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth"
+        res
+        == "https://staging.cell-a.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth"
     )
 
     res = settings.get_keycloak_auth_endpoint(override_env="staging")
     assert (
-        res == "https://staging.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth"
+        res
+        == "https://staging.cell-a.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth"
     )
 
     res = settings.get_keycloak_auth_endpoint(override_env="production")
@@ -56,13 +58,13 @@ def test_get_keycloak_device_auth_endpoint(settings):
     res = settings.get_keycloak_device_auth_endpoint()
     assert (
         res
-        == "https://staging.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth/device"
+        == "https://staging.cell-a.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth/device"
     )
 
     res = settings.get_keycloak_device_auth_endpoint(override_env="staging")
     assert (
         res
-        == "https://staging.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth/device"
+        == "https://staging.cell-a.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth/device"
     )
 
     res = settings.get_keycloak_device_auth_endpoint(override_env="production")
@@ -76,13 +78,13 @@ def test_get_keycloak_user_info_endpoint(settings):
     res = settings.get_keycloak_user_info_endpoint()
     assert (
         res
-        == "https://staging.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/userinfo"
+        == "https://staging.cell-a.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/userinfo"
     )
 
     res = settings.get_keycloak_user_info_endpoint(override_env="staging")
     assert (
         res
-        == "https://staging.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/userinfo"
+        == "https://staging.cell-a.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/userinfo"
     )
 
     res = settings.get_keycloak_user_info_endpoint(override_env="production")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,7 +2,7 @@ import pytest
 
 from obi_auth import exception
 
-PROD_OBI_URL = "https://www.openbraininstitute.org"
+PROD_OBI_URL = "https://cell-a.openbraininstitute.org"
 STAGING_OBI_URL = "https://staging.cell-a.openbraininstitute.org"
 
 
@@ -14,7 +14,7 @@ def test_get_keycloak_url(settings):
     assert res == "https://staging.cell-a.openbraininstitute.org/auth/realms/SBO"
 
     res = settings.get_keycloak_url(override_env="production")
-    assert res == "https://www.openbraininstitute.org/auth/realms/SBO"
+    assert res == "https://cell-a.openbraininstitute.org/auth/realms/SBO"
 
     with pytest.raises(exception.ConfigError, match="Unknown deployment environment foo"):
         settings.get_keycloak_url(override_env="foo")
@@ -34,7 +34,9 @@ def test_get_keycloak_token_endpoint(settings):
     )
 
     res = settings.get_keycloak_token_endpoint(override_env="production")
-    assert res == "https://www.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/token"
+    assert (
+        res == "https://cell-a.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/token"
+    )
 
 
 def test_get_keycloak_auth_endpoint(settings):
@@ -51,7 +53,9 @@ def test_get_keycloak_auth_endpoint(settings):
     )
 
     res = settings.get_keycloak_auth_endpoint(override_env="production")
-    assert res == "https://www.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth"
+    assert (
+        res == "https://cell-a.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth"
+    )
 
 
 def test_get_keycloak_device_auth_endpoint(settings):
@@ -70,7 +74,7 @@ def test_get_keycloak_device_auth_endpoint(settings):
     res = settings.get_keycloak_device_auth_endpoint(override_env="production")
     assert (
         res
-        == "https://www.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth/device"
+        == "https://cell-a.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/auth/device"
     )
 
 
@@ -89,7 +93,8 @@ def test_get_keycloak_user_info_endpoint(settings):
 
     res = settings.get_keycloak_user_info_endpoint(override_env="production")
     assert (
-        res == "https://www.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/userinfo"
+        res
+        == "https://cell-a.openbraininstitute.org/auth/realms/SBO/protocol/openid-connect/userinfo"
     )
 
 


### PR DESCRIPTION
Rename domain urls:
* https://staging.openbraininstitute.org -> https://staging.cell-a.openbraininstitute.org
* https://cell-a.openbraininstitute.org -> https://cell-a.openbraininstitute.org