### PR TITLE
Add utility to fetch persistent token id from access token

### DIFF
--- a/src/obi_auth/request.py
+++ b/src/obi_auth/request.py
@@ -1,9 +1,13 @@
 """Requests module."""
 
+import logging
+
 import httpx
 
 from obi_auth.config import settings
-from obi_auth.typedef import DeploymentEnvironment
+from obi_auth.typedef import DeploymentEnvironment, PersistenceMode
+
+L = logging.getLogger(__name__)
 
 
 def exchange_code_for_token(
@@ -38,3 +42,37 @@ def user_info(
     response = httpx.post(url, headers={"Authorization": f"Bearer {token}"})
     response.raise_for_status()
     return response
+
+
+def get_persistent_token_id(
+    access_token: str,
+    persistence_mode: PersistenceMode = PersistenceMode.refresh,
+    environment: DeploymentEnvironment | None = None,
+) -> str:
+    """Get a persistent token id with an access token."""
+    auth_manager_url = settings.get_auth_manager_url(environment)
+
+    mode_to_endpoint = {
+        PersistenceMode.offline: f"{auth_manager_url}/offline-token-id",
+        PersistenceMode.refresh: f"{auth_manager_url}/refresh-token-id",
+    }
+
+    js = (
+        httpx.request(
+            url=mode_to_endpoint[persistence_mode],
+            method="POST",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        .raise_for_status()
+        .json()
+    )
+
+    # refresh-token-id -> {"data": {"id": ...}}
+    # offline-token-id -> {"data": {"persistent_token_id": ...}}
+    if persistent_token_id := js.get("data", {}).get("id") or js.get("data", {}).get(
+        "persistent_token_id"
+    ):
+        return persistent_token_id
+
+    L.error("AuthManager unexpected payload: {}", js)
+    raise RuntimeError(f"AuthManager unexpected payload: {js}")

--- a/src/obi_auth/typedef.py
+++ b/src/obi_auth/typedef.py
@@ -47,3 +47,10 @@ class AuthDeviceInfo(BaseModel):
     def max_retries(self) -> int:
         """Return max retries from expiration time and polling interval."""
         return self.expires_in // self.interval
+
+
+class PersistenceMode(StrEnum):
+    """Refresh token persistence model."""
+
+    refresh = auto()
+    offline = auto()


### PR DESCRIPTION
For testing purposes.

```python
from obi_auth import get_token
from obi_auth.request import get_persistent_token_id

access_token = "fetch-access-token-from-platform"

persistent_token_id = get_persistent_token_id(token)

access_token = get_token(auth_mode="persistent_token", persistent_token_id=persistent_token_id)

```