### PR TITLE
Improve CLI experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,59 @@ from obi_auth import get_token
 access_token = get_token(environment="staging")
 ```
 
+## CLI
+
+After installation, the `obi-auth` command is available. Run `obi-auth --help` for the full list of commands and options.
+
+### `get-token`
+
+Authenticate and print the access token to stdout. Output is a single token string, suitable for piping into other commands.
+
+```sh
+obi-auth get-token
+obi-auth get-token -e production -m daf
+obi-auth get-token --force-refresh
+```
+
+| Option | Description |
+| --- | --- |
+| `-e`, `--environment` | Target environment: `staging` (default) or `production` |
+| `-m`, `--auth-mode` | Authentication method: `pkce` (default) or `daf` |
+| `--force-refresh` | Clear the cached token and authenticate again |
+
+### `decode-token`
+
+Decode a JWT and print the payload as indented JSON. Pass the token as an argument or via stdin.
+
+```sh
+obi-auth decode-token eyJhbGciOi...
+obi-auth get-token | obi-auth decode-token
+obi-auth get-token | obi-auth decode-token | jq -r '.sub'
+```
+
+### `get-user-info`
+
+Authenticate, fetch user info from Keycloak, and print the result as indented JSON.
+
+```sh
+obi-auth get-user-info
+obi-auth get-user-info -e production -m daf
+obi-auth get-user-info --force-refresh
+obi-auth get-user-info | jq -r '.sub'
+```
+
+| Option | Description |
+| --- | --- |
+| `-e`, `--environment` | Target environment: `staging` (default) or `production` |
+| `-m`, `--auth-mode` | Authentication method: `pkce` (default) or `daf` |
+| `--force-refresh` | Clear the cached token and authenticate again |
+
+### Global options
+
+| Option | Description |
+| --- | --- |
+| `--log-level` | Logging level: `DEBUG`, `INFO`, `WARNING` (default), `ERROR`, `CRITICAL` |
+
 ## License
 
 Copyright (c) 2025 Open Brain Institute

--- a/src/obi_auth/cli.py
+++ b/src/obi_auth/cli.py
@@ -35,11 +35,19 @@ def main(log_level):
 )
 @click.option("--show-decoded", help="Show decoded information", is_flag=True, default=False)
 @click.option("--show-user-info", help="Show user info information", is_flag=True, default=False)
-def get_token(environment, auth_mode, show_decoded, show_user_info):
+@click.option(
+    "--force-refresh",
+    help="Clear the cached token and authenticate again",
+    is_flag=True,
+    default=False,
+)
+def get_token(environment, auth_mode, show_decoded, show_user_info, force_refresh):
     """Authenticate, print the token to stdout."""
     environment = DeploymentEnvironment(environment)
 
-    access_token = obi_auth.get_token(environment=environment, auth_mode=AuthMode(auth_mode))
+    access_token = obi_auth.get_token(
+        environment=environment, auth_mode=AuthMode(auth_mode), force_refresh=force_refresh
+    )
     print(access_token)
 
 
@@ -65,8 +73,16 @@ def decode_token(access_token):
     type=click.Choice([mode.value for mode in AuthMode]),
 )
 @click.option("--environment", "-e", default="staging", help="The person to greet")
-def get_user_info(environment, auth_mode):
+@click.option(
+    "--force-refresh",
+    help="Clear the cached token and authenticate again",
+    is_flag=True,
+    default=False,
+)
+def get_user_info(environment, auth_mode, force_refresh):
     """Show user info information."""
     environment = DeploymentEnvironment(environment)
-    access_token = obi_auth.get_token(environment=environment, auth_mode=AuthMode(auth_mode))
+    access_token = obi_auth.get_token(
+        environment=environment, auth_mode=AuthMode(auth_mode), force_refresh=force_refresh
+    )
     print(json.dumps(obi_auth.get_user_info(access_token, environment=environment), indent=2))

--- a/src/obi_auth/cli.py
+++ b/src/obi_auth/cli.py
@@ -33,15 +33,13 @@ def main(log_level):
     help="Authentication method",
     type=click.Choice([mode.value for mode in AuthMode]),
 )
-@click.option("--show-decoded", help="Show decoded information", is_flag=True, default=False)
-@click.option("--show-user-info", help="Show user info information", is_flag=True, default=False)
 @click.option(
     "--force-refresh",
     help="Clear the cached token and authenticate again",
     is_flag=True,
     default=False,
 )
-def get_token(environment, auth_mode, show_decoded, show_user_info, force_refresh):
+def get_token(environment, auth_mode, force_refresh):
     """Authenticate, print the token to stdout."""
     environment = DeploymentEnvironment(environment)
 

--- a/src/obi_auth/cli.py
+++ b/src/obi_auth/cli.py
@@ -1,8 +1,9 @@
 #!/bin/env python3
 """CLI for obi-auth."""
 
+import json
 import logging
-import pprint
+import sys
 
 import click
 
@@ -41,8 +42,31 @@ def get_token(environment, auth_mode, show_decoded, show_user_info):
     access_token = obi_auth.get_token(environment=environment, auth_mode=AuthMode(auth_mode))
     print(access_token)
 
-    if show_decoded:
-        pprint.pprint(obi_auth.get_token_info(access_token))
 
-    if show_user_info:
-        pprint.pprint(obi_auth.get_user_info(access_token, environment=environment))
+@main.command()
+@click.argument("access_token", required=False)
+def decode_token(access_token):
+    """Decode token from argument or stdin."""
+    if not access_token:
+        access_token = sys.stdin.read().strip()
+
+    if not access_token:
+        raise click.ClickException("No access token provided via argument or stdin")
+
+    print(json.dumps(obi_auth.get_token_info(access_token), indent=2))
+
+
+@main.command()
+@click.option(
+    "--auth-mode",
+    "-m",
+    default="pkce",
+    help="Authentication method",
+    type=click.Choice([mode.value for mode in AuthMode]),
+)
+@click.option("--environment", "-e", default="staging", help="The person to greet")
+def get_user_info(environment, auth_mode):
+    """Show user info information."""
+    environment = DeploymentEnvironment(environment)
+    access_token = obi_auth.get_token(environment=environment, auth_mode=AuthMode(auth_mode))
+    print(json.dumps(obi_auth.get_user_info(access_token, environment=environment), indent=2))

--- a/src/obi_auth/client.py
+++ b/src/obi_auth/client.py
@@ -26,6 +26,7 @@ def get_token(
     *,
     environment: DeploymentEnvironment = DeploymentEnvironment.staging,
     auth_mode: AuthMode = AuthMode.pkce,
+    force_refresh: bool = False,
     **auth_mode_kwargs,
 ) -> str:
     """Get token."""
@@ -40,7 +41,10 @@ def get_token(
         else None,
     )
 
-    if token := _TOKEN_CACHE.get(storage):
+    if force_refresh:
+        L.debug("Forcing token refresh, clearing cached token")
+        storage.clear()
+    elif token := _TOKEN_CACHE.get(storage):
         L.debug("Using cached token")
         return token
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -40,7 +40,9 @@ def test_get_token(mock_token, cli_runner):
     result = cli_runner.invoke(main, ["get-token"])
     assert result.exit_code == 0
     assert result.output == "foo\n"
-    mock_token.assert_called_with(environment=DeploymentEnvironment.staging, auth_mode=AuthMode.pkce)
+    mock_token.assert_called_with(
+        environment=DeploymentEnvironment.staging, auth_mode=AuthMode.pkce
+    )
 
     result = cli_runner.invoke(
         main, ["get-token", "-e", "production", "-m", "daf", "--show-decoded", "--show-user-info"]
@@ -162,12 +164,12 @@ def test_get_token_piped_to_decode_token_with_jq(tmp_path):
     decode_token_cmd = [obi_auth_cli, "decode-token"]
     jq_cmd = ["jq", "-r", ".sub"]
 
-    get_token = subprocess.Popen(get_token_cmd, stdout=subprocess.PIPE, text=True, env=env)
-    decode_token = subprocess.Popen(
+    get_token = subprocess.Popen(get_token_cmd, stdout=subprocess.PIPE, text=True, env=env)  # noqa: S603
+    decode_token = subprocess.Popen(  # noqa: S603
         decode_token_cmd, stdin=get_token.stdout, stdout=subprocess.PIPE, text=True, env=env
     )
     get_token.stdout.close()
-    jq = subprocess.Popen(jq_cmd, stdin=decode_token.stdout, stdout=subprocess.PIPE, text=True)
+    jq = subprocess.Popen(jq_cmd, stdin=decode_token.stdout, stdout=subprocess.PIPE, text=True)  # noqa: S603
     decode_token.stdout.close()
 
     stdout, stderr = jq.communicate()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -44,12 +44,6 @@ def test_get_token(mock_token, cli_runner):
         environment=DeploymentEnvironment.staging, auth_mode=AuthMode.pkce, force_refresh=False
     )
 
-    result = cli_runner.invoke(
-        main, ["get-token", "-e", "production", "-m", "daf", "--show-decoded", "--show-user-info"]
-    )
-    assert result.exit_code == 0
-    assert result.output == "foo\n"
-
 
 @patch("obi_auth.get_token")
 def test_get_token_force_refresh(mock_token, cli_runner):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -34,14 +34,14 @@ def test_get_token(mock_token, cli_runner):
     assert result.exit_code == 0
     assert result.output == "foo\n"
     mock_token.assert_called_with(
-        environment=DeploymentEnvironment.production, auth_mode=AuthMode.daf
+        environment=DeploymentEnvironment.production, auth_mode=AuthMode.daf, force_refresh=False
     )
 
     result = cli_runner.invoke(main, ["get-token"])
     assert result.exit_code == 0
     assert result.output == "foo\n"
     mock_token.assert_called_with(
-        environment=DeploymentEnvironment.staging, auth_mode=AuthMode.pkce
+        environment=DeploymentEnvironment.staging, auth_mode=AuthMode.pkce, force_refresh=False
     )
 
     result = cli_runner.invoke(
@@ -49,6 +49,20 @@ def test_get_token(mock_token, cli_runner):
     )
     assert result.exit_code == 0
     assert result.output == "foo\n"
+
+
+@patch("obi_auth.get_token")
+def test_get_token_force_refresh(mock_token, cli_runner):
+    mock_token.return_value = "fresh-token"
+
+    result = cli_runner.invoke(
+        main, ["get-token", "-e", "production", "-m", "daf", "--force-refresh"]
+    )
+    assert result.exit_code == 0
+    assert result.output == "fresh-token\n"
+    mock_token.assert_called_with(
+        environment=DeploymentEnvironment.production, auth_mode=AuthMode.daf, force_refresh=True
+    )
 
 
 @patch("obi_auth.get_token_info")
@@ -106,7 +120,7 @@ def test_get_user_info(mock_token, mock_user_info, cli_runner):
     assert json.loads(result.output) == user_info
     assert result.output == json.dumps(user_info, indent=2) + "\n"
     mock_token.assert_called_once_with(
-        environment=DeploymentEnvironment.production, auth_mode=AuthMode.daf
+        environment=DeploymentEnvironment.production, auth_mode=AuthMode.daf, force_refresh=False
     )
     mock_user_info.assert_called_once_with(
         "access-token", environment=DeploymentEnvironment.production
@@ -125,11 +139,28 @@ def test_get_user_info_defaults(mock_token, mock_user_info, cli_runner):
     assert result.exit_code == 0
     assert json.loads(result.output) == user_info
     mock_token.assert_called_once_with(
-        environment=DeploymentEnvironment.staging, auth_mode=AuthMode.pkce
+        environment=DeploymentEnvironment.staging, auth_mode=AuthMode.pkce, force_refresh=False
     )
     mock_user_info.assert_called_once_with(
         "staging-token", environment=DeploymentEnvironment.staging
     )
+
+
+@patch("obi_auth.get_user_info")
+@patch("obi_auth.get_token")
+def test_get_user_info_force_refresh(mock_token, mock_user_info, cli_runner):
+    user_info = {"email": "test@example.com"}
+    mock_token.return_value = "fresh-token"
+    mock_user_info.return_value = user_info
+
+    result = cli_runner.invoke(main, ["get-user-info", "--force-refresh"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == user_info
+    mock_token.assert_called_once_with(
+        environment=DeploymentEnvironment.staging, auth_mode=AuthMode.pkce, force_refresh=True
+    )
+    mock_user_info.assert_called_once_with("fresh-token", environment=DeploymentEnvironment.staging)
 
 
 @pytest.mark.skipif(shutil.which("jq") is None, reason="jq not installed")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,9 +1,18 @@
+import json
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
 from unittest.mock import patch
 
+import jwt
 import pytest
 from click.testing import CliRunner
 
 from obi_auth.cli import main
+from obi_auth.typedef import AuthMode, DeploymentEnvironment
 
 
 @pytest.fixture
@@ -17,32 +26,155 @@ def test_help(cli_runner):
     assert result.exit_code == 0
 
 
-@patch("obi_auth.get_user_info")
-@patch("obi_auth.get_token_info")
 @patch("obi_auth.get_token")
-def test_get_token(mock_token, mock_info, mock_user, cli_runner):
+def test_get_token(mock_token, cli_runner):
     mock_token.return_value = "foo"
-    mock_info.return_value = "bar"
-    mock_user.return_value = "zee"
 
     result = cli_runner.invoke(main, ["get-token", "-e", "production", "-m", "daf"])
+    assert result.exit_code == 0
     assert result.output == "foo\n"
-
-    result = cli_runner.invoke(
-        main, ["get-token", "-e", "production", "-m", "daf", "--show-decoded"]
+    mock_token.assert_called_with(
+        environment=DeploymentEnvironment.production, auth_mode=AuthMode.daf
     )
-    assert "foo" in result.output
-    assert "bar" in result.output
 
-    result = cli_runner.invoke(
-        main, ["get-token", "-e", "production", "-m", "daf", "--show-user-info"]
-    )
-    assert "foo" in result.output
-    assert "zee" in result.output
+    result = cli_runner.invoke(main, ["get-token"])
+    assert result.exit_code == 0
+    assert result.output == "foo\n"
+    mock_token.assert_called_with(environment=DeploymentEnvironment.staging, auth_mode=AuthMode.pkce)
 
     result = cli_runner.invoke(
         main, ["get-token", "-e", "production", "-m", "daf", "--show-decoded", "--show-user-info"]
     )
-    assert "foo" in result.output
-    assert "bar" in result.output
-    assert "zee" in result.output
+    assert result.exit_code == 0
+    assert result.output == "foo\n"
+
+
+@patch("obi_auth.get_token_info")
+def test_decode_token_with_argument(mock_token_info, cli_runner):
+    token_info = {"sub": "user-123", "exp": 1_700_000_000}
+    mock_token_info.return_value = token_info
+
+    result = cli_runner.invoke(main, ["decode-token", "my-access-token"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == token_info
+    assert result.output == json.dumps(token_info, indent=2) + "\n"
+    mock_token_info.assert_called_once_with("my-access-token")
+
+
+@patch("obi_auth.get_token_info")
+def test_decode_token_from_stdin(mock_token_info, cli_runner):
+    token_info = {"sub": "user-456"}
+    mock_token_info.return_value = token_info
+
+    result = cli_runner.invoke(main, ["decode-token"], input="stdin-access-token\n")
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == token_info
+    mock_token_info.assert_called_once_with("stdin-access-token")
+
+
+@patch("obi_auth.get_token_info")
+def test_decode_token_strips_stdin_whitespace(mock_token_info, cli_runner):
+    mock_token_info.return_value = {"sub": "user-789"}
+
+    result = cli_runner.invoke(main, ["decode-token"], input="  trimmed-token  \n")
+
+    assert result.exit_code == 0
+    mock_token_info.assert_called_once_with("trimmed-token")
+
+
+def test_decode_token_without_input_raises(cli_runner):
+    result = cli_runner.invoke(main, ["decode-token"])
+
+    assert result.exit_code != 0
+    assert "No access token provided via argument or stdin" in result.output
+
+
+@patch("obi_auth.get_user_info")
+@patch("obi_auth.get_token")
+def test_get_user_info(mock_token, mock_user_info, cli_runner):
+    user_info = {"email": "test@example.com", "preferred_username": "tester"}
+    mock_token.return_value = "access-token"
+    mock_user_info.return_value = user_info
+
+    result = cli_runner.invoke(main, ["get-user-info", "-e", "production", "-m", "daf"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == user_info
+    assert result.output == json.dumps(user_info, indent=2) + "\n"
+    mock_token.assert_called_once_with(
+        environment=DeploymentEnvironment.production, auth_mode=AuthMode.daf
+    )
+    mock_user_info.assert_called_once_with(
+        "access-token", environment=DeploymentEnvironment.production
+    )
+
+
+@patch("obi_auth.get_user_info")
+@patch("obi_auth.get_token")
+def test_get_user_info_defaults(mock_token, mock_user_info, cli_runner):
+    user_info = {"email": "staging@example.com"}
+    mock_token.return_value = "staging-token"
+    mock_user_info.return_value = user_info
+
+    result = cli_runner.invoke(main, ["get-user-info"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == user_info
+    mock_token.assert_called_once_with(
+        environment=DeploymentEnvironment.staging, auth_mode=AuthMode.pkce
+    )
+    mock_user_info.assert_called_once_with(
+        "staging-token", environment=DeploymentEnvironment.staging
+    )
+
+
+@pytest.mark.skipif(shutil.which("jq") is None, reason="jq not installed")
+def test_get_token_piped_to_decode_token_with_jq(tmp_path):
+    """obi-auth get-token | obi-auth decode-token | jq -r '.sub'"""
+    obi_auth_cli = Path(sys.executable).parent / "obi-auth"
+    if not obi_auth_cli.exists():
+        obi_auth_cli = shutil.which("obi-auth")
+    if obi_auth_cli is None:
+        pytest.skip("obi-auth CLI not installed")
+    obi_auth_cli = str(obi_auth_cli)
+    token = jwt.encode({"sub": "piped-user"}, key=None, algorithm="none")
+
+    sitecustomize = tmp_path / "sitecustomize.py"
+    sitecustomize.write_text(
+        textwrap.dedent(
+            f"""
+            import obi_auth
+
+            obi_auth.get_token = lambda **kwargs: {token!r}
+            """
+        )
+    )
+
+    env = os.environ.copy()
+    pythonpath = [str(tmp_path)]
+    if existing_pythonpath := env.get("PYTHONPATH"):
+        pythonpath.append(existing_pythonpath)
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath)
+
+    get_token_cmd = [obi_auth_cli, "get-token"]
+    decode_token_cmd = [obi_auth_cli, "decode-token"]
+    jq_cmd = ["jq", "-r", ".sub"]
+
+    get_token = subprocess.Popen(get_token_cmd, stdout=subprocess.PIPE, text=True, env=env)
+    decode_token = subprocess.Popen(
+        decode_token_cmd, stdin=get_token.stdout, stdout=subprocess.PIPE, text=True, env=env
+    )
+    get_token.stdout.close()
+    jq = subprocess.Popen(jq_cmd, stdin=decode_token.stdout, stdout=subprocess.PIPE, text=True)
+    decode_token.stdout.close()
+
+    stdout, stderr = jq.communicate()
+    decode_token.wait()
+    get_token.wait()
+
+    assert get_token.returncode == 0, stderr
+    assert decode_token.returncode == 0, stderr
+    assert jq.returncode == 0, stderr
+    assert stdout == "piped-user\n"

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -21,6 +21,21 @@ def test_get_token(mock_cache, mock_method):
     assert test_module.get_token() == "mock-token"
 
 
+@patch("obi_auth.client.Storage")
+@patch("obi_auth.client._get_auth_method")
+@patch("obi_auth.client._TOKEN_CACHE")
+def test_get_token_force_refresh(mock_cache, mock_method, mock_storage):
+    mock_cache.get.return_value = "cached-token"
+    mock_method.return_value = lambda *args, **kwargs: "fresh-token"
+
+    result = test_module.get_token(force_refresh=True)
+
+    assert result == "fresh-token"
+    mock_cache.get.assert_not_called()
+    mock_storage.return_value.clear.assert_called_once_with()
+    mock_cache.set.assert_called_once_with("fresh-token", mock_storage.return_value)
+
+
 def test_get_auth_method():
     res = test_module._get_auth_method(AuthMode.pkce)
     assert res is test_module._pkce_authenticate


### PR DESCRIPTION
### Summary
This PR refactors the obi-auth CLI around composable, pipe-friendly commands. The main goal is to keep get-token focused on emitting a single access token to stdout, while moving inspection and user-info lookup into dedicated subcommands with consistent JSON output.

### get-token — token only on stdout
get-token now prints only the raw access token (plus a trailing newline). It no longer decodes the token or fetches user info inline.

The `--show-decoded` and -`-show-user-info` flags are removed.

### decode-token — inspect a token (new)
A new decode-token command decodes a JWT and prints the payload as indented JSON.

Pass the token as an argument: obi-auth decode-token <token>
Or pipe it in from stdin: obi-auth get-token | obi-auth decode-token
This makes it easy to chain with standard Unix tools, for example:

```obi-auth get-token | obi-auth decode-token | jq -r '.sub' ```

### get-user-info — fetch Keycloak user info (new)
A new get-user-info command authenticates (via get-token under the hood), calls the Keycloak userinfo endpoint, and prints the result as indented JSON.

It supports the same -e / --environment and -m / --auth-mode options as get-token (defaults: staging, pkce).

### --force-refresh — bypass the token cache
Both get-token and get-user-info now accept a --force-refresh flag. When set, it clears the cached token for the target environment and forces a fresh authentication instead of reusing a still-valid cached token.

```
obi-auth get-token --force-refresh
obi-auth get-user-info --force-refresh
```

### Output format
Decoded token payloads and user info are now emitted as JSON (json.dumps(..., indent=2)) instead of Python pprint, which is easier to read in the terminal and parse with tools like jq.

