### PR TITLE
Replace unmaintained httpx with httpx2

### DIFF
--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build SDist
         run: pipx run build --sdist
@@ -24,7 +24,7 @@ jobs:
       - name: Check metadata
         run: pipx run twine check dist/*
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build
           path: dist
@@ -39,7 +39,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: build
           path: dist

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -25,9 +25,9 @@ jobs:
           tox-env: check-packaging
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -39,7 +39,7 @@ jobs:
         tox run -e ${{ matrix.tox-env }}
     - name: Upload to codecov
       if: ${{ matrix.codecov == 'codecov' }}
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ local_scheme = "no-local-version"
 addopts = [
     "-vv",
     "-ra",
+    "-p pytest_httpx2",
     "--import-mode=importlib",
     "--cov=obi_auth",
     "--durations=10",
@@ -147,7 +148,7 @@ extras = ["notebook"]
 deps = [
     "pytest",
     "pytest-cov",
-    "httpx2-pytest",
+    "pytest-httpx2",
     "coverage[toml]",
 ]
 commands = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "obi_auth"
 dependencies = [
     "click",
     "cryptography>=3.0",
-    "httpx",
+    "httpx2",
     "pydantic",
     "pydantic-settings",
     "pyjwt",
@@ -147,7 +147,7 @@ extras = ["notebook"]
 deps = [
     "pytest",
     "pytest-cov",
-    "pytest-httpx",
+    "httpx2-pytest",
     "coverage[toml]",
 ]
 commands = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ local_scheme = "no-local-version"
 addopts = [
     "-vv",
     "-ra",
-    "-p pytest_httpx2",
     "--import-mode=importlib",
     "--cov=obi_auth",
     "--durations=10",

--- a/src/obi_auth/flows/auth_manager.py
+++ b/src/obi_auth/flows/auth_manager.py
@@ -2,7 +2,7 @@
 
 import logging
 
-import httpx
+import httpx2
 
 from obi_auth.config import settings
 from obi_auth.exception import AuthFlowError
@@ -20,7 +20,7 @@ def auth_manager_mint_access_token(
 ) -> AuthManagerTokenInfo:
     """Mint an auth-manager access token from a persistent token id."""
     mint_data = (
-        httpx.post(
+        httpx2.post(
             url=settings.get_auth_manager_access_token_endpoint(override_env=environment),
             headers={"id": persistent_token_id},
         )
@@ -41,7 +41,7 @@ def auth_manager_exchange_token(
 ) -> AuthManagerTokenInfo:
     """Exchange a Keycloak access token and mint an auth-manager access token."""
     exchange_data = (
-        httpx.post(
+        httpx2.post(
             url=settings.get_auth_manager_token_exchange_endpoint(override_env=environment),
             headers={"Authorization": f"Bearer {token_info.access_token}"},
         )

--- a/src/obi_auth/flows/daf.py
+++ b/src/obi_auth/flows/daf.py
@@ -4,7 +4,7 @@ import logging
 from time import sleep
 from typing import TypedDict
 
-import httpx
+import httpx2
 
 from obi_auth.config import settings
 from obi_auth.exception import AuthFlowError
@@ -53,7 +53,7 @@ def _get_device_url_code(
     environment: DeploymentEnvironment,
 ) -> AuthDeviceInfo:
     url = settings.get_keycloak_device_auth_endpoint(environment)
-    response = httpx.post(
+    response = httpx2.post(
         url=url,
         data={
             "client_id": settings.KEYCLOAK_CLIENT_ID,
@@ -77,7 +77,7 @@ def _get_device_code_token(
     device_info: AuthDeviceInfo, environment: DeploymentEnvironment
 ) -> str | None:
     url = settings.get_keycloak_token_endpoint(environment)
-    response = httpx.post(
+    response = httpx2.post(
         url=url,
         data={
             "grant_type": "urn:ietf:params:oauth:grant-type:device_code",

--- a/src/obi_auth/request.py
+++ b/src/obi_auth/request.py
@@ -1,6 +1,6 @@
 """Requests module."""
 
-import httpx
+import httpx2
 
 from obi_auth.config import settings
 from obi_auth.typedef import DeploymentEnvironment
@@ -15,7 +15,7 @@ def exchange_code_for_token(
 ):
     """Exhange authentication code for acces token response."""
     url = settings.get_keycloak_token_endpoint(override_env)
-    response = httpx.post(
+    response = httpx2.post(
         url=url,
         data={
             "grant_type": "authorization_code",
@@ -35,6 +35,6 @@ def user_info(
 ):
     """Request user info with a valid token."""
     url = settings.get_keycloak_user_info_endpoint(environment)
-    response = httpx.post(url, headers={"Authorization": f"Bearer {token}"})
+    response = httpx2.post(url, headers={"Authorization": f"Bearer {token}"})
     response.raise_for_status()
     return response

--- a/tests/unit/flows/test_auth_manager.py
+++ b/tests/unit/flows/test_auth_manager.py
@@ -6,41 +6,33 @@ from obi_auth.flows import auth_manager as test_module
 from obi_auth.typedef import AuthManagerTokenInfo, KeycloakTokenInfo
 
 
-def test_auth_manager_mint_access_token(httpx_mock):
-    httpx_mock.add_response(
-        method="POST",
-        url=settings.get_auth_manager_access_token_endpoint(override_env="staging"),
-        json={"data": {"access_token": "minted-token"}},
-    )
+def test_auth_manager_mint_access_token(httpx2_mock):
+    httpx2_mock.post(
+        settings.get_auth_manager_access_token_endpoint(override_env="staging")
+    ).respond(json={"data": {"access_token": "minted-token"}})
     res = test_module.auth_manager_mint_access_token("persistent-id", environment="staging")
     assert res == AuthManagerTokenInfo(
         access_token="minted-token",  # noqa: S106
         persistent_token_id="persistent-id",  # noqa: S106
     )
-    assert httpx_mock.get_request().headers["id"] == "persistent-id"
+    assert httpx2_mock.calls[0].request.headers["id"] == "persistent-id"
 
 
-def test_auth_manager_mint_access_token__raises(httpx_mock):
-    httpx_mock.add_response(
-        method="POST",
-        url=settings.get_auth_manager_access_token_endpoint(override_env="staging"),
-        json={"data": {}},
-    )
+def test_auth_manager_mint_access_token__raises(httpx2_mock):
+    httpx2_mock.post(
+        settings.get_auth_manager_access_token_endpoint(override_env="staging")
+    ).respond(json={"data": {}})
     with pytest.raises(AuthFlowError, match="AuthManager unexpected payload"):
         test_module.auth_manager_mint_access_token("persistent-id", environment="staging")
 
 
-def test_auth_manager_exchange_token(httpx_mock):
-    httpx_mock.add_response(
-        method="POST",
-        url=settings.get_auth_manager_token_exchange_endpoint(override_env="staging"),
-        json={"data": {"id": "exchanged-id"}},
-    )
-    httpx_mock.add_response(
-        method="POST",
-        url=settings.get_auth_manager_access_token_endpoint(override_env="staging"),
-        json={"data": {"access_token": "minted-token"}},
-    )
+def test_auth_manager_exchange_token(httpx2_mock):
+    httpx2_mock.post(
+        settings.get_auth_manager_token_exchange_endpoint(override_env="staging")
+    ).respond(json={"data": {"id": "exchanged-id"}})
+    httpx2_mock.post(
+        settings.get_auth_manager_access_token_endpoint(override_env="staging")
+    ).respond(json={"data": {"access_token": "minted-token"}})
 
     res = test_module.auth_manager_exchange_token(
         KeycloakTokenInfo(access_token="public-token"),  # noqa: S106
@@ -50,17 +42,15 @@ def test_auth_manager_exchange_token(httpx_mock):
         access_token="minted-token",  # noqa: S106
         persistent_token_id="exchanged-id",  # noqa: S106
     )
-    requests = httpx_mock.get_requests()
+    requests = [call.request for call in httpx2_mock.calls]
     assert requests[0].headers["Authorization"] == "Bearer public-token"
     assert requests[1].headers["id"] == "exchanged-id"
 
 
-def test_auth_manager_exchange_token__exchange_raises(httpx_mock):
-    httpx_mock.add_response(
-        method="POST",
-        url=settings.get_auth_manager_token_exchange_endpoint(override_env="staging"),
-        json={"data": {}},
-    )
+def test_auth_manager_exchange_token__exchange_raises(httpx2_mock):
+    httpx2_mock.post(
+        settings.get_auth_manager_token_exchange_endpoint(override_env="staging")
+    ).respond(json={"data": {}})
     with pytest.raises(AuthFlowError, match="AuthManager unexpected payload"):
         test_module.auth_manager_exchange_token(
             KeycloakTokenInfo(access_token="public-token"),  # noqa: S106
@@ -68,17 +58,13 @@ def test_auth_manager_exchange_token__exchange_raises(httpx_mock):
         )
 
 
-def test_auth_manager_exchange_token__mint_raises(httpx_mock):
-    httpx_mock.add_response(
-        method="POST",
-        url=settings.get_auth_manager_token_exchange_endpoint(override_env="staging"),
-        json={"data": {"id": "exchanged-id"}},
-    )
-    httpx_mock.add_response(
-        method="POST",
-        url=settings.get_auth_manager_access_token_endpoint(override_env="staging"),
-        json={"data": {}},
-    )
+def test_auth_manager_exchange_token__mint_raises(httpx2_mock):
+    httpx2_mock.post(
+        settings.get_auth_manager_token_exchange_endpoint(override_env="staging")
+    ).respond(json={"data": {"id": "exchanged-id"}})
+    httpx2_mock.post(
+        settings.get_auth_manager_access_token_endpoint(override_env="staging")
+    ).respond(json={"data": {}})
     with pytest.raises(AuthFlowError, match="AuthManager unexpected payload"):
         test_module.auth_manager_exchange_token(
             KeycloakTokenInfo(access_token="public-token"),  # noqa: S106

--- a/tests/unit/flows/test_daf.py
+++ b/tests/unit/flows/test_daf.py
@@ -59,13 +59,14 @@ def test_daf_authenticate_failure(
     mock_print.assert_called_with("\r   ✗ Authentication failed - timeout reached", flush=True)
 
 
-def test_device_code_token(httpx_mock, device_info):
-    httpx_mock.add_response(method="POST", json={"access_token": "foo"})
+def test_device_code_token(httpx2_mock, device_info):
+    httpx2_mock.post().respond(json={"access_token": "foo"})
 
     res = test_module._get_device_code_token(device_info, None)
     assert res == "foo"
 
-    httpx_mock.add_response(method="POST", status_code=400, json={"error": "authorization_pending"})
+    httpx2_mock.reset()
+    httpx2_mock.post().respond(400, json={"error": "authorization_pending"})
     res = test_module._get_device_code_token(device_info, None)
     assert res is None
 

--- a/tests/unit/flows/test_daf.py
+++ b/tests/unit/flows/test_daf.py
@@ -158,7 +158,7 @@ def test_display_notebook_auth_prompt_fallback(mock_terminal, mock_console, devi
     mock_terminal.assert_called_once_with(device_info)
 
 
-@patch("obi_auth.flows.daf.httpx.post")
+@patch("obi_auth.flows.daf.httpx2.post")
 def test_get_device_url_code(mock_post, device_info):
     """Test _get_device_url_code function."""
     mock_response = mock_post.return_value

--- a/tests/unit/flows/test_pkce.py
+++ b/tests/unit/flows/test_pkce.py
@@ -21,8 +21,8 @@ def test_build_auth_url():
     )
 
 
-def test_exchange_code_for_token(httpx_mock):
-    httpx_mock.add_response(method="POST", json={"access_token": "mock-token"})
+def test_exchange_code_for_token(httpx2_mock):
+    httpx2_mock.post().respond(json={"access_token": "mock-token"})
     res = test_module._exchange_code_for_token(
         code="mock-code",
         redirect_uri="mock-uri",

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -201,8 +201,8 @@ def test_get_auth_method():
 
 @patch("obi_auth.flows.pkce.webbrowser")
 @patch("obi_auth.client.AuthServer")
-def test_pkce_authenticate(mock_server, mock_web, httpx_mock):
-    httpx_mock.add_response(method="POST", json={"access_token": "mock-token"})
+def test_pkce_authenticate(mock_server, mock_web, httpx2_mock):
+    httpx2_mock.post().respond(json={"access_token": "mock-token"})
 
     mock_local = Mock()
     mock_local.redirect_uri = "mock-redirect-uri"
@@ -228,7 +228,7 @@ def test_pkce_authenticate(mock_server, mock_web, httpx_mock):
 
 
 @patch("obi_auth.client.daf_authenticate")
-def test_daf_authenticate(auth_method, httpx_mock):
+def test_daf_authenticate(auth_method):
     auth_method.side_effect = exception.AuthFlowError()
     with pytest.raises(exception.ClientError, match="Authentication process failed."):
         test_module._daf_authenticate(environment=None)
@@ -243,14 +243,12 @@ def test_get_token_info():
     assert decoded == payload
 
 
-def test_get_user_info(httpx_mock, settings):
+def test_get_user_info(httpx2_mock, settings):
     mock_json_response = {"foo": "bar", "bar": "foo"}
 
-    httpx_mock.add_response(
-        method="POST",
-        url=settings.get_keycloak_user_info_endpoint(override_env="staging"),
-        json=mock_json_response,
-    )
+    httpx2_mock.post(
+        settings.get_keycloak_user_info_endpoint(override_env="staging")
+    ).respond(json=mock_json_response)
 
     res = test_module.get_user_info(token=None, environment="staging")
     assert res == mock_json_response

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -246,9 +246,9 @@ def test_get_token_info():
 def test_get_user_info(httpx2_mock, settings):
     mock_json_response = {"foo": "bar", "bar": "foo"}
 
-    httpx2_mock.post(
-        settings.get_keycloak_user_info_endpoint(override_env="staging")
-    ).respond(json=mock_json_response)
+    httpx2_mock.post(settings.get_keycloak_user_info_endpoint(override_env="staging")).respond(
+        json=mock_json_response
+    )
 
     res = test_module.get_user_info(token=None, environment="staging")
     assert res == mock_json_response

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,6 +1,6 @@
 import socket
 
-import httpx
+import httpx2
 import pytest
 
 from obi_auth import server as test_module
@@ -38,10 +38,10 @@ def test_wait_for_code(running_server):
     with pytest.raises(LocalServerError, match="Timeout waiting for authorization code"):
         running_server.wait_for_code(timeout=0.1)
 
-    response = httpx.get(f"{running_server.redirect_uri}")
+    response = httpx2.get(f"{running_server.redirect_uri}")
     assert response.status_code == 400
 
-    response = httpx.get(f"{running_server.redirect_uri}?code=mock-code")
+    response = httpx2.get(f"{running_server.redirect_uri}?code=mock-code")
     response.raise_for_status()
 
     res = running_server.wait_for_code()
@@ -49,7 +49,7 @@ def test_wait_for_code(running_server):
 
 
 def test_unknown_path_returns_not_found(running_server):
-    response = httpx.get(f"http://localhost:{running_server.port}/unknown")
+    response = httpx2.get(f"http://localhost:{running_server.port}/unknown")
     assert response.status_code == 404
     assert response.json() == {"detail": "Not Found"}
 


### PR DESCRIPTION
## Summary
- Swap `httpx` for Pydantic-maintained `httpx2` across runtime code and tests
- Replace `pytest-httpx` with `httpx2-pytest` so the existing `httpx_mock` fixture keeps working