### PR TITLE
Make click an optional CLI dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ obi-auth is a library for retrieving Keycloak access tokens interactively. It he
 pip install obi-auth
 ```
 
+### CLI Support
+
+To use the `obi-auth` command-line interface:
+
+```sh
+pip install obi-auth[cli]
+```
+
+This installs `click` which is required by the CLI.
+
 ### Notebook Support
 
 For enhanced Jupyter notebook support with Rich display integration:
@@ -40,7 +50,7 @@ access_token = get_token(environment="staging", token_provider="auth_manager")
 
 ## CLI
 
-After installation, the `obi-auth` command is available. Run `obi-auth --help` for the full list of commands and options.
+After installing with the `cli` extra, the `obi-auth` command is available. Run `obi-auth --help` for the full list of commands and options.
 
 ### `get-token`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "obi_auth"
 dependencies = [
-    "click",
     "cryptography>=3.0",
     "httpx2",
     "pydantic",
@@ -30,6 +29,9 @@ classifiers = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
+cli = [
+    "click",
+]
 notebook = [
     "rich",
 ]
@@ -143,7 +145,7 @@ env_list = [
 ]
 
 [tool.tox.env_run_base]
-extras = ["notebook"]
+extras = ["cli", "notebook"]
 deps = [
     "pytest",
     "pytest-cov",

--- a/src/obi_auth/cli.py
+++ b/src/obi_auth/cli.py
@@ -4,7 +4,14 @@ import json
 import logging
 import sys
 
-import click
+try:
+    import click
+except ImportError as exc:
+    raise SystemExit(
+        "The obi-auth CLI requires optional dependencies that are not installed.\n"
+        "Install them with:\n"
+        "  pip install 'obi-auth[cli]'"
+    ) from exc
 
 import obi_auth
 from obi_auth.typedef import AuthMode, DeploymentEnvironment, TokenProvider

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -22,46 +22,46 @@ def cli_runner():
 
 def test_missing_cli_extra_shows_install_hint():
     """Running the CLI entry without click should explain how to install the extra."""
-    script = textwrap.dedent(
-        """
-        import builtins
-        import sys
+    import builtins
+    import importlib
 
-        real_import = builtins.__import__
+    real_import = builtins.__import__
+    saved_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "click"
+        or name.startswith("click.")
+        or name == "obi_auth.cli"
+        or name.startswith("obi_auth.cli.")
+    }
 
-        def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
-            if name == "click" or name.startswith("click."):
-                raise ImportError("No module named 'click'")
-            return real_import(name, globals, locals, fromlist, level)
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "click" or name.startswith("click."):
+            raise ImportError("No module named 'click'")
+        return real_import(name, globals, locals, fromlist, level)
 
+    try:
         builtins.__import__ = guarded_import
+        for module_name in saved_modules:
+            del sys.modules[module_name]
+
+        with pytest.raises(SystemExit) as exc_info:
+            importlib.import_module("obi_auth.cli")
+
+        message = str(exc_info.value)
+        assert "pip install 'obi-auth[cli]'" in message
+        assert "optional dependencies" in message
+    finally:
+        builtins.__import__ = real_import
         for module_name in list(sys.modules):
-            if module_name == "click" or module_name.startswith("click."):
+            if (
+                module_name == "click"
+                or module_name.startswith("click.")
+                or module_name == "obi_auth.cli"
+                or module_name.startswith("obi_auth.cli.")
+            ):
                 del sys.modules[module_name]
-            if module_name == "obi_auth.cli" or module_name.startswith("obi_auth.cli."):
-                del sys.modules[module_name]
-
-        try:
-            import obi_auth.cli  # noqa: F401
-        except SystemExit as exc:
-            message = str(exc)
-            if message and message != "1":
-                print(message, file=sys.stderr)
-            raise SystemExit(1) from None
-        raise SystemExit("expected SystemExit when click is missing")
-        """
-    )
-
-    result = subprocess.run(  # noqa: S603
-        [sys.executable, "-c", script],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    assert result.returncode == 1
-    assert "pip install 'obi-auth[cli]'" in result.stderr
-    assert "optional dependencies" in result.stderr
+        sys.modules.update(saved_modules)
 
 
 def test_help(cli_runner):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,9 +1,12 @@
+import builtins
+import importlib
 import json
 import os
 import shutil
 import subprocess
 import sys
 import textwrap
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
@@ -15,6 +18,40 @@ from obi_auth.cli import main
 from obi_auth.typedef import AuthMode, DeploymentEnvironment, TokenProvider
 
 
+def _is_click_or_cli_module(name: str) -> bool:
+    return (
+        name == "click"
+        or name.startswith("click.")
+        or name == "obi_auth.cli"
+        or name.startswith("obi_auth.cli.")
+    )
+
+
+@contextmanager
+def _without_click():
+    """Temporarily pretend click (and the CLI module) are not installed."""
+    real_import = builtins.__import__
+    saved_modules = {
+        name: module for name, module in sys.modules.items() if _is_click_or_cli_module(name)
+    }
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "click" or name.startswith("click."):
+            raise ImportError("No module named 'click'")
+        return real_import(name, *args, **kwargs)
+
+    builtins.__import__ = guarded_import
+    for module_name in saved_modules:
+        del sys.modules[module_name]
+    try:
+        yield
+    finally:
+        builtins.__import__ = real_import
+        for module_name in [name for name in sys.modules if _is_click_or_cli_module(name)]:
+            del sys.modules[module_name]
+        sys.modules.update(saved_modules)
+
+
 @pytest.fixture
 def cli_runner():
     return CliRunner()
@@ -22,46 +59,12 @@ def cli_runner():
 
 def test_missing_cli_extra_shows_install_hint():
     """Running the CLI entry without click should explain how to install the extra."""
-    import builtins
-    import importlib
+    with _without_click(), pytest.raises(SystemExit) as exc_info:
+        importlib.import_module("obi_auth.cli")
 
-    real_import = builtins.__import__
-    saved_modules = {
-        name: module
-        for name, module in sys.modules.items()
-        if name == "click"
-        or name.startswith("click.")
-        or name == "obi_auth.cli"
-        or name.startswith("obi_auth.cli.")
-    }
-
-    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name == "click" or name.startswith("click."):
-            raise ImportError("No module named 'click'")
-        return real_import(name, globals, locals, fromlist, level)
-
-    try:
-        builtins.__import__ = guarded_import
-        for module_name in saved_modules:
-            del sys.modules[module_name]
-
-        with pytest.raises(SystemExit) as exc_info:
-            importlib.import_module("obi_auth.cli")
-
-        message = str(exc_info.value)
-        assert "pip install 'obi-auth[cli]'" in message
-        assert "optional dependencies" in message
-    finally:
-        builtins.__import__ = real_import
-        for module_name in list(sys.modules):
-            if (
-                module_name == "click"
-                or module_name.startswith("click.")
-                or module_name == "obi_auth.cli"
-                or module_name.startswith("obi_auth.cli.")
-            ):
-                del sys.modules[module_name]
-        sys.modules.update(saved_modules)
+    message = str(exc_info.value)
+    assert "pip install 'obi-auth[cli]'" in message
+    assert "optional dependencies" in message
 
 
 def test_help(cli_runner):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -20,6 +20,50 @@ def cli_runner():
     return CliRunner()
 
 
+def test_missing_cli_extra_shows_install_hint():
+    """Running the CLI entry without click should explain how to install the extra."""
+    script = textwrap.dedent(
+        """
+        import builtins
+        import sys
+
+        real_import = builtins.__import__
+
+        def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "click" or name.startswith("click."):
+                raise ImportError("No module named 'click'")
+            return real_import(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = guarded_import
+        for module_name in list(sys.modules):
+            if module_name == "click" or module_name.startswith("click."):
+                del sys.modules[module_name]
+            if module_name == "obi_auth.cli" or module_name.startswith("obi_auth.cli."):
+                del sys.modules[module_name]
+
+        try:
+            import obi_auth.cli  # noqa: F401
+        except SystemExit as exc:
+            message = str(exc)
+            if message and message != "1":
+                print(message, file=sys.stderr)
+            raise SystemExit(1) from None
+        raise SystemExit("expected SystemExit when click is missing")
+        """
+    )
+
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "pip install 'obi-auth[cli]'" in result.stderr
+    assert "optional dependencies" in result.stderr
+
+
 def test_help(cli_runner):
     result = cli_runner.invoke(main, ["--help"])
     assert "CLI for obi-auth" in result.output


### PR DESCRIPTION
## Summary
- Move `click` from core dependencies into the optional `[cli]` extra so library-only installs stay lean
- Document `pip install obi-auth[cli]` and show a clear install hint when the CLI is run without click
- Include `cli` in tox extras so CLI tests still get click