### PR TITLE
Require OAuth state on the PKCE local callback

### DIFF
--- a/src/obi_auth/flows/pkce.py
+++ b/src/obi_auth/flows/pkce.py
@@ -5,6 +5,7 @@ import hashlib
 import logging
 import os
 import re
+import secrets
 import urllib.parse
 import webbrowser
 
@@ -27,8 +28,16 @@ def _generate_pkce_pair() -> tuple[str, str]:
     return code_verifier, code_challenge
 
 
+def _generate_state() -> str:
+    """Generate a cryptographically random OAuth state value."""
+    return secrets.token_urlsafe(32)
+
+
 def _build_auth_url(
-    code_challenge: str, redirect_uri: str, override_env: DeploymentEnvironment | None
+    code_challenge: str,
+    redirect_uri: str,
+    state: str,
+    override_env: DeploymentEnvironment | None,
 ) -> str:
     """Construct authentication url to open with a browser."""
     params = {
@@ -36,6 +45,7 @@ def _build_auth_url(
         "client_id": settings.KEYCLOAK_CLIENT_ID,
         "redirect_uri": redirect_uri,
         "scope": "openid",
+        "state": state,
         "code_challenge": code_challenge,
         "code_challenge_method": "S256",
         "kc_idp_hint": "github",
@@ -52,7 +62,9 @@ def _authorize(
     server: AuthServer, code_challenge: str, override_env: DeploymentEnvironment | None
 ) -> str:
     """Ask user to login in order to retrieve a code to exchange for a token."""
-    auth_url = _build_auth_url(code_challenge, server.redirect_uri, override_env)
+    state = _generate_state()
+    server.expect_state(state)
+    auth_url = _build_auth_url(code_challenge, server.redirect_uri, state, override_env)
     L.info("Authentication url: %s", auth_url)
     webbrowser.open(auth_url)
     return server.wait_for_code()

--- a/src/obi_auth/server.py
+++ b/src/obi_auth/server.py
@@ -105,8 +105,6 @@ class AuthServer:
             raise LocalServerError("Server has no port assigned.")
         return f"http://{HOST}:{self.port}{CALLBACK_PATH}"
 
-<<<<<<< HEAD
-=======
     def expect_state(self, state: str) -> None:
         """Record the OAuth state that the callback must present."""
         self.auth_state.expected_state = state
@@ -122,7 +120,6 @@ class AuthServer:
             s.bind(("", 0))
             return s.getsockname()[1]
 
->>>>>>> 47bd31c (Require OAuth state on the PKCE local callback.)
     @contextlib.contextmanager
     def run(self) -> Iterator[Self]:
         """Start server in a background thread on an OS-assigned port.

--- a/src/obi_auth/server.py
+++ b/src/obi_auth/server.py
@@ -113,13 +113,6 @@ class AuthServer:
         self.auth_state.error_description = None
         self.auth_state.event.clear()
 
-    @staticmethod
-    def _find_free_port() -> int:
-        """Bind to port 0 to let the OS select a free port, then return that port."""
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("", 0))
-            return s.getsockname()[1]
-
     @contextlib.contextmanager
     def run(self) -> Iterator[Self]:
         """Start server in a background thread on an OS-assigned port.

--- a/src/obi_auth/server.py
+++ b/src/obi_auth/server.py
@@ -24,7 +24,10 @@ CALLBACK_PATH = "/callback"
 class AuthState:
     """Class to manage authentication state."""
 
+    expected_state: str | None = None
     code: str | None = None
+    error: str | None = None
+    error_description: str | None = None
     event: threading.Event = field(default_factory=threading.Event)
 
 
@@ -44,14 +47,30 @@ class _CallbackHandler(BaseHTTPRequestHandler):
             self._respond(HTTPStatus.NOT_FOUND, {"detail": "Not Found"})
             return
 
-        codes = parse_qs(url.query).get("code")
+        params = parse_qs(url.query)
+        state = (params.get("state") or [None])[0]
 
+        if self.auth_state.expected_state is None or state != self.auth_state.expected_state:
+            L.warning("Rejecting callback with missing or mismatched OAuth state")
+            self._respond(HTTPStatus.BAD_REQUEST, {"detail": "Invalid OAuth state"})
+            return
+
+        if errors := params.get("error"):
+            self.auth_state.error = errors[0]
+            descriptions = params.get("error_description")
+            self.auth_state.error_description = descriptions[0] if descriptions else None
+            self.auth_state.event.set()
+            detail = self.auth_state.error_description or self.auth_state.error
+            self._respond(HTTPStatus.BAD_REQUEST, {"detail": detail})
+            return
+
+        codes = params.get("code")
         if not codes:
             self._respond(HTTPStatus.BAD_REQUEST, {"detail": "Authorization code not found"})
             return
 
         self.auth_state.code = codes[0]
-        self.auth_state.event.set()  # Signal that we received the code
+        self.auth_state.event.set()
 
         self._respond(
             HTTPStatus.OK, {"message": "Authentication successful. You can close this window."}
@@ -86,6 +105,24 @@ class AuthServer:
             raise LocalServerError("Server has no port assigned.")
         return f"http://{HOST}:{self.port}{CALLBACK_PATH}"
 
+<<<<<<< HEAD
+=======
+    def expect_state(self, state: str) -> None:
+        """Record the OAuth state that the callback must present."""
+        self.auth_state.expected_state = state
+        self.auth_state.code = None
+        self.auth_state.error = None
+        self.auth_state.error_description = None
+        self.auth_state.event.clear()
+
+    @staticmethod
+    def _find_free_port() -> int:
+        """Bind to port 0 to let the OS select a free port, then return that port."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("", 0))
+            return s.getsockname()[1]
+
+>>>>>>> 47bd31c (Require OAuth state on the PKCE local callback.)
     @contextlib.contextmanager
     def run(self) -> Iterator[Self]:
         """Start server in a background thread on an OS-assigned port.
@@ -113,10 +150,15 @@ class AuthServer:
             server.server_close()
 
     def wait_for_code(self, timeout: int = settings.LOCAL_SERVER_TIMEOUT) -> str:
-        """Wait for code."""
+        """Wait for a validated authorization code, or raise on OAuth/timeout errors."""
         if self.auth_state.event.wait(timeout):
             self.auth_state.event.clear()
+            if self.auth_state.error is not None:
+                detail = self.auth_state.error_description or self.auth_state.error
+                raise LocalServerError(f"Authorization failed: {detail}")
             if self.auth_state.code is None:
                 raise LocalServerError("Authorization code was not set")
-            return self.auth_state.code
+            code = self.auth_state.code
+            self.auth_state.code = None
+            return code
         raise LocalServerError("Timeout waiting for authorization code")

--- a/tests/unit/flows/test_pkce.py
+++ b/tests/unit/flows/test_pkce.py
@@ -7,6 +7,7 @@ def test_build_auth_url():
     res = test_module._build_auth_url(
         code_challenge="foo",
         redirect_uri="bar",
+        state="csrf-state",
         override_env=None,
     )
     assert res == (
@@ -15,6 +16,7 @@ def test_build_auth_url():
         "&client_id=obi-entitysdk-auth"
         "&redirect_uri=bar"
         "&scope=openid"
+        "&state=csrf-state"
         "&code_challenge=foo"
         "&code_challenge_method=S256"
         "&kc_idp_hint=github"
@@ -32,9 +34,11 @@ def test_exchange_code_for_token(httpx2_mock):
     assert res == "mock-token"
 
 
+@patch("obi_auth.flows.pkce._generate_state", return_value="generated-state")
 @patch("obi_auth.flows.pkce.webbrowser")
-def test_authorize(mocked_webbrowser):
+def test_authorize(mocked_webbrowser, mock_generate_state):
     mock_server = Mock()
+    mock_server.redirect_uri = "http://localhost:8000/callback"
     mock_server.wait_for_code.return_value = "mock-code"
 
     res = test_module._authorize(
@@ -43,3 +47,7 @@ def test_authorize(mocked_webbrowser):
         override_env=None,
     )
     assert res == "mock-code"
+    mock_server.expect_state.assert_called_once_with("generated-state")
+    mocked_webbrowser.open.assert_called_once()
+    opened_url = mocked_webbrowser.open.call_args.args[0]
+    assert "state=generated-state" in opened_url

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -111,8 +111,10 @@ def test_concurrent_servers_get_distinct_ports():
     server_b = AuthServer()
     with server_a.run() as a, server_b.run() as b:
         assert a.port != b.port
-        assert httpx2.get(f"{a.redirect_uri}?code=a").status_code == 200
-        assert httpx2.get(f"{b.redirect_uri}?code=b").status_code == 200
+        a.expect_state("state-a")
+        b.expect_state("state-b")
+        assert httpx2.get(f"{a.redirect_uri}?code=a&state=state-a").status_code == 200
+        assert httpx2.get(f"{b.redirect_uri}?code=b&state=state-b").status_code == 200
         assert a.wait_for_code(timeout=1) == "a"
         assert b.wait_for_code(timeout=1) == "b"
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -29,17 +29,58 @@ def test_redirect_uri(server):
 
 
 def test_wait_for_code(running_server):
+    running_server.expect_state("expected-state")
+
     with pytest.raises(LocalServerError, match="Timeout waiting for authorization code"):
         running_server.wait_for_code(timeout=0.1)
 
     response = httpx2.get(f"{running_server.redirect_uri}")
     assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid OAuth state"}
 
-    response = httpx2.get(f"{running_server.redirect_uri}?code=mock-code")
+    response = httpx2.get(f"{running_server.redirect_uri}?code=mock-code&state=wrong-state")
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid OAuth state"}
+
+    response = httpx2.get(f"{running_server.redirect_uri}?code=mock-code&state=expected-state")
     response.raise_for_status()
 
     res = running_server.wait_for_code()
     assert res == "mock-code"
+    assert running_server.auth_state.code is None
+
+
+def test_wait_for_code_oauth_error(running_server):
+    running_server.expect_state("expected-state")
+
+    response = httpx2.get(
+        f"{running_server.redirect_uri}"
+        "?error=access_denied&error_description=User+denied&state=expected-state"
+    )
+    assert response.status_code == 400
+    assert response.json() == {"detail": "User denied"}
+
+    with pytest.raises(LocalServerError, match="Authorization failed: User denied"):
+        running_server.wait_for_code(timeout=1)
+
+
+def test_wait_for_code_oauth_error_without_description(running_server):
+    running_server.expect_state("expected-state")
+
+    response = httpx2.get(f"{running_server.redirect_uri}?error=access_denied&state=expected-state")
+    assert response.status_code == 400
+    assert response.json() == {"detail": "access_denied"}
+
+    with pytest.raises(LocalServerError, match="Authorization failed: access_denied"):
+        running_server.wait_for_code(timeout=1)
+
+
+def test_callback_valid_state_missing_code(running_server):
+    running_server.expect_state("expected-state")
+
+    response = httpx2.get(f"{running_server.redirect_uri}?state=expected-state")
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Authorization code not found"}
 
 
 def test_unknown_path_returns_not_found(running_server):
@@ -120,7 +161,14 @@ def test_run_does_not_probe_then_rebind(server, monkeypatch):
 
 
 def test_wait_for_code_missing_code(server):
+    server.expect_state("expected-state")
     server.auth_state.event.set()
 
     with pytest.raises(LocalServerError, match="Authorization code was not set"):
         server.wait_for_code()
+
+
+def test_callback_rejects_code_without_expected_state(running_server):
+    response = httpx2.get(f"{running_server.redirect_uri}?code=mock-code&state=any")
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid OAuth state"}


### PR DESCRIPTION
## Summary
- **Issue:** The PKCE flow spun up a localhost callback that accepted any `GET /callback?code=...`. There was no OAuth `state` parameter, so a forged or raced request to that endpoint could inject an authorization code and complete the interactive login (classic login CSRF / callback hijack against a localhost redirect URI). Failed Keycloak redirects (`error` / `error_description`) were also ignored and looked like a missing code.
- **Fix:** Generate a random `state` for each PKCE attempt, send it on the authorize URL, and reject callbacks whose `state` does not match (without unblocking the waiter, so a bad request cannot steal the flow). Valid Keycloak error redirects are surfaced as `LocalServerError`. The authorization code is cleared after a successful wait.
- Adds unit coverage for matching/mismatched state, missing state, OAuth errors, and the PKCE URL wiring.