### PR TITLE
Fix auth-manager unexpected-payload error formatting

### DIFF
--- a/src/obi_auth/flows/auth_manager.py
+++ b/src/obi_auth/flows/auth_manager.py
@@ -29,7 +29,7 @@ def auth_manager_mint_access_token(
     )
 
     if not (access_token := mint_data.get("data", {}).get("access_token")):
-        msg = "AuthManager unexpected payload: {}", mint_data
+        msg = f"AuthManager unexpected payload: {mint_data}"
         L.error(msg)
         raise AuthFlowError(msg)
 
@@ -50,7 +50,7 @@ def auth_manager_exchange_token(
     )
 
     if not (token_id := exchange_data.get("data", {}).get("id")):
-        msg = "AuthManager unexpected payload: {}", exchange_data
+        msg = f"AuthManager unexpected payload: {exchange_data}"
         L.error(msg)
         raise AuthFlowError(msg)
 

--- a/tests/unit/flows/test_auth_manager.py
+++ b/tests/unit/flows/test_auth_manager.py
@@ -22,8 +22,11 @@ def test_auth_manager_mint_access_token__raises(httpx2_mock):
     httpx2_mock.post(
         settings.get_auth_manager_access_token_endpoint(override_env="staging")
     ).respond(json={"data": {}})
-    with pytest.raises(AuthFlowError, match="AuthManager unexpected payload"):
+    with pytest.raises(
+        AuthFlowError, match=r"AuthManager unexpected payload: \{'data': \{\}\}"
+    ) as exc_info:
         test_module.auth_manager_mint_access_token("persistent-id", environment="staging")
+    assert isinstance(exc_info.value.args[0], str)
 
 
 def test_auth_manager_exchange_token(httpx2_mock):
@@ -51,11 +54,14 @@ def test_auth_manager_exchange_token__exchange_raises(httpx2_mock):
     httpx2_mock.post(
         settings.get_auth_manager_token_exchange_endpoint(override_env="staging")
     ).respond(json={"data": {}})
-    with pytest.raises(AuthFlowError, match="AuthManager unexpected payload"):
+    with pytest.raises(
+        AuthFlowError, match=r"AuthManager unexpected payload: \{'data': \{\}\}"
+    ) as exc_info:
         test_module.auth_manager_exchange_token(
             KeycloakTokenInfo(access_token="public-token"),  # noqa: S106
             environment="staging",
         )
+    assert isinstance(exc_info.value.args[0], str)
 
 
 def test_auth_manager_exchange_token__mint_raises(httpx2_mock):


### PR DESCRIPTION
## Summary
- Auth-manager mint/exchange failure paths used `msg = "...{}", data`, which creates a **tuple** rather than a formatted string.
- That meant `L.error` and `AuthFlowError` did not include the unexpected payload as intended.
- Switch to f-strings and tighten tests so the exception message is a string that includes the payload.