### PR TITLE
Bind PKCE callback once to close port TOCTOU race

### DIFF
--- a/src/obi_auth/server.py
+++ b/src/obi_auth/server.py
@@ -4,10 +4,9 @@ import contextlib
 import functools
 import json
 import logging
-import socket
 import threading
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Self
@@ -26,7 +25,7 @@ class AuthState:
     """Class to manage authentication state."""
 
     code: str | None = None
-    event: threading.Event = threading.Event()
+    event: threading.Event = field(default_factory=threading.Event)
 
 
 class _CallbackHandler(BaseHTTPRequestHandler):
@@ -87,23 +86,21 @@ class AuthServer:
             raise LocalServerError("Server has no port assigned.")
         return f"http://{HOST}:{self.port}{CALLBACK_PATH}"
 
-    @staticmethod
-    def _find_free_port() -> int:
-        """Bind to port 0 to let the OS select a free port, then return that port."""
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("", 0))
-            return s.getsockname()[1]
-
     @contextlib.contextmanager
     def run(self) -> Iterator[Self]:
-        """Start server in a background thread."""
-        self.port = self._find_free_port()
+        """Start server in a background thread on an OS-assigned port.
+
+        The server binds once to port ``0`` so the kernel picks a free port on the
+        listening socket itself. This avoids the TOCTOU race of probing for a free
+        port, releasing it, then binding again.
+        """
         handler = functools.partial(_CallbackHandler, auth_state=self.auth_state)
         try:
-            server = ThreadingHTTPServer((HOST, self.port), handler)
+            server = ThreadingHTTPServer((HOST, 0), handler)
         except OSError as e:
-            raise LocalServerError(f"Failed to listen on {HOST}:{self.port}") from e
+            raise LocalServerError(f"Failed to listen on {HOST}") from e
 
+        self.port = server.server_address[1]
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         try:
             thread.start()

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,5 +1,3 @@
-import socket
-
 import httpx2
 import pytest
 
@@ -21,10 +19,6 @@ def running_server(server):
 
 def test_server(server):
     assert isinstance(server, AuthServer)
-
-
-def test_find_free_port():
-    assert AuthServer._find_free_port() > 0
 
 
 def test_redirect_uri(server):
@@ -54,17 +48,75 @@ def test_unknown_path_returns_not_found(running_server):
     assert response.json() == {"detail": "Not Found"}
 
 
-def test_run_port_unavailable(server, monkeypatch):
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as taken:
-        taken.bind(("localhost", 0))
-        taken.listen(1)
-        monkeypatch.setattr(
-            AuthServer, "_find_free_port", staticmethod(lambda: taken.getsockname()[1])
-        )
+def test_run_assigns_port_from_listening_socket(running_server):
+    assert isinstance(running_server.port, int)
+    assert running_server.port > 0
+    assert running_server.redirect_uri == f"http://localhost:{running_server.port}/callback"
 
-        with pytest.raises(LocalServerError, match="Failed to listen on localhost:"):
-            with server.run():
-                pass
+    # The reported port must be the one actually accepting connections.
+    response = httpx2.get(f"http://localhost:{running_server.port}/callback")
+    assert response.status_code == 400
+
+
+def test_run_binds_localhost_only(running_server):
+    # Binding to localhost must not expose the callback on a non-loopback wildcard probe.
+    # Connecting via 127.0.0.1 (loopback) should work; that is what HOST resolves to.
+    response = httpx2.get(f"http://127.0.0.1:{running_server.port}/callback")
+    assert response.status_code == 400
+
+
+def test_concurrent_servers_get_distinct_ports():
+    server_a = AuthServer()
+    server_b = AuthServer()
+    with server_a.run() as a, server_b.run() as b:
+        assert a.port != b.port
+        assert httpx2.get(f"{a.redirect_uri}?code=a").status_code == 200
+        assert httpx2.get(f"{b.redirect_uri}?code=b").status_code == 200
+        assert a.wait_for_code(timeout=1) == "a"
+        assert b.wait_for_code(timeout=1) == "b"
+
+
+def test_run_stops_listening_after_context_exit(server):
+    with server.run() as local_server:
+        port = local_server.port
+        assert httpx2.get(f"http://localhost:{port}/callback").status_code == 400
+
+    with pytest.raises(httpx2.ConnectError):
+        httpx2.get(f"http://localhost:{port}/callback", timeout=0.5)
+
+
+def test_run_bind_failure(server, monkeypatch):
+    def boom(*_args, **_kwargs):
+        raise OSError("Address already in use")
+
+    monkeypatch.setattr(test_module, "ThreadingHTTPServer", boom)
+
+    with pytest.raises(LocalServerError, match="Failed to listen on localhost") as exc_info:
+        with server.run():
+            pass
+
+    assert isinstance(exc_info.value.__cause__, OSError)
+    assert server.port is None
+
+
+def test_run_does_not_probe_then_rebind(server, monkeypatch):
+    """Ensure we bind the listening server once (no separate free-port probe)."""
+    bind_calls: list[tuple[str, int]] = []
+    real_server = test_module.ThreadingHTTPServer
+
+    class TrackingServer(real_server):
+        def server_bind(self):
+            bind_calls.append(self.server_address)
+            return super().server_bind()
+
+    monkeypatch.setattr(test_module, "ThreadingHTTPServer", TrackingServer)
+
+    with server.run() as local_server:
+        assert len(bind_calls) == 1
+        assert bind_calls[0] == ("localhost", 0)
+        assert local_server.port > 0
+        # Port reported to callers must match the bound listening socket.
+        assert local_server.port != 0
 
 
 def test_wait_for_code_missing_code(server):


### PR DESCRIPTION
## Summary

### Problem before

The local PKCE callback server used a two-step port selection:

1. `_find_free_port()` opened a temporary socket, bound it to port `0` (so the OS picked a free port, e.g. `54321`), read that number, then **closed the socket**.
2. `ThreadingHTTPServer` was started on that same numeric port.

That is a classic **TOCTOU** (time-of-check / time-of-use) race: between releasing the probe socket and binding the real HTTP server, another local process can bind `54321`. Outcomes include:

- The auth server fails to bind, or binds a different port than the one already put in the Keycloak `redirect_uri`.
- Worse, a malicious or opportunistic local listener can sit on the port the browser was told to use and intercept the OAuth redirect (authorization code).

The probe also bound `("", 0)` (all interfaces) while the real server listened on `localhost` only, so “free on wildcard” did not even mean “free on localhost.”

### What we do now

`AuthServer.run()` starts `ThreadingHTTPServer((localhost, 0), ...)` **once**:

- Port `0` means “ask the kernel for any free port” on the **listening** socket itself.
- After bind, the OS replaces `0` with a concrete port; we read it from `server.server_address[1]` and use that in `redirect_uri`.
- There is no probe / release / rebind. The port in the redirect URL is the port that is already accepting connections.

### Why this is better

- **No race window** between discovering a port and owning it.
- **Redirect URI matches reality**: Keycloak sends the browser to the socket we are actually listening on.
- **Still ephemeral**: we do not hard-code a port; the OS still picks a free one.
- **Same localhost-only binding** as before for the real server (`HOST = "localhost"`).

### Other small fix

`AuthState.event` now uses `field(default_factory=threading.Event)` so concurrent `AuthServer` instances do not share one `Event` (mutable dataclass default).

### Tests

Coverage for: port comes from the listening socket; loopback access works; concurrent servers get distinct ports; server stops after context exit; bind failure raises; exactly one bind to `("localhost", 0)` (no separate free-port probe).