### PR TITLE
Redact PKCE callback logs and stop logging the authorize URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ obi-auth is a library for retrieving Keycloak access tokens interactively. It he
 
 > [!CAUTION]
 > obi-auth is designed to be used interactively and should not be used within a service or application.
+>
+> `get-token` prints a live access token to stdout. Prefer piping it into the command that needs it, and avoid pasting tokens into tickets, chat, or shell history. Prefer stdin over CLI arguments for `decode-token` (arguments can appear in `ps` and shell history):
+> `obi-auth get-token | obi-auth decode-token`
+>
+> Avoid `--log-level DEBUG` on shared machines. Callback request logs redact `code`, `state`, and `error_description`, but DEBUG still increases what is written to the console.
 
 ## Installation
 
@@ -81,10 +86,9 @@ obi-auth get-token --force-refresh
 
 ### `decode-token`
 
-Decode a JWT and print the payload as indented JSON. Pass the token as an argument or via stdin.
+Decode a JWT and print the payload as indented JSON. Prefer piping the token via stdin.
 
 ```sh
-obi-auth decode-token eyJhbGciOi...
 obi-auth get-token | obi-auth decode-token
 obi-auth get-token | obi-auth decode-token | jq -r '.sub'
 ```

--- a/src/obi_auth/flows/pkce.py
+++ b/src/obi_auth/flows/pkce.py
@@ -65,7 +65,7 @@ def _authorize(
     state = _generate_state()
     server.expect_state(state)
     auth_url = _build_auth_url(code_challenge, server.redirect_uri, state, override_env)
-    L.info("Authentication url: %s", auth_url)
+    L.info("Opening browser for authentication")
     webbrowser.open(auth_url)
     return server.wait_for_code()
 

--- a/src/obi_auth/server.py
+++ b/src/obi_auth/server.py
@@ -4,6 +4,7 @@ import contextlib
 import functools
 import json
 import logging
+import re
 import threading
 from collections.abc import Iterator
 from dataclasses import dataclass, field
@@ -18,6 +19,16 @@ from obi_auth.exception import LocalServerError
 L = logging.getLogger(__name__)
 HOST = "localhost"
 CALLBACK_PATH = "/callback"
+_REDACTED_QUERY_PARAMS = ("code", "state", "error_description")
+_REDACT_QUERY_RE = re.compile(
+    rf"((?:[?&])(?:{'|'.join(_REDACTED_QUERY_PARAMS)})=)[^&\s]*",
+    re.IGNORECASE,
+)
+
+
+def _redact_request_log(message: str) -> str:
+    """Replace sensitive OAuth query values in an HTTP access-log line."""
+    return _REDACT_QUERY_RE.sub(r"\1[redacted]", message)
 
 
 @dataclass
@@ -87,7 +98,7 @@ class _CallbackHandler(BaseHTTPRequestHandler):
 
     def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
         """Redirect the request logs to this module's logger instead of stderr."""
-        L.debug("%s - %s", self.address_string(), format % args)
+        L.debug("%s - %s", self.address_string(), _redact_request_log(format % args))
 
 
 class AuthServer:

--- a/tests/unit/flows/test_pkce.py
+++ b/tests/unit/flows/test_pkce.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import Mock, patch
 
 from obi_auth.flows import pkce as test_module
@@ -36,18 +37,23 @@ def test_exchange_code_for_token(httpx2_mock):
 
 @patch("obi_auth.flows.pkce._generate_state", return_value="generated-state")
 @patch("obi_auth.flows.pkce.webbrowser")
-def test_authorize(mocked_webbrowser, mock_generate_state):
+def test_authorize(mocked_webbrowser, mock_generate_state, caplog):
     mock_server = Mock()
     mock_server.redirect_uri = "http://localhost:8000/callback"
     mock_server.wait_for_code.return_value = "mock-code"
 
-    res = test_module._authorize(
-        server=mock_server,
-        code_challenge="mock-challenge",
-        override_env=None,
-    )
+    with caplog.at_level(logging.INFO, logger="obi_auth.flows.pkce"):
+        res = test_module._authorize(
+            server=mock_server,
+            code_challenge="mock-challenge",
+            override_env=None,
+        )
     assert res == "mock-code"
     mock_server.expect_state.assert_called_once_with("generated-state")
     mocked_webbrowser.open.assert_called_once()
     opened_url = mocked_webbrowser.open.call_args.args[0]
     assert "state=generated-state" in opened_url
+    assert "Opening browser for authentication" in caplog.text
+    assert opened_url not in caplog.text
+    assert "generated-state" not in caplog.text
+    assert "mock-challenge" not in caplog.text

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,3 +1,5 @@
+import logging
+
 import httpx2
 import pytest
 
@@ -174,3 +176,38 @@ def test_callback_rejects_code_without_expected_state(running_server):
     response = httpx2.get(f"{running_server.redirect_uri}?code=mock-code&state=any")
     assert response.status_code == 400
     assert response.json() == {"detail": "Invalid OAuth state"}
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        (
+            '"GET /callback?code=secret-code&state=csrf HTTP/1.1" 200 -',
+            '"GET /callback?code=[redacted]&state=[redacted] HTTP/1.1" 200 -',
+        ),
+        (
+            '"GET /callback?error=access_denied'
+            '&error_description=User+denied&state=csrf HTTP/1.1" 400 -',
+            '"GET /callback?error=access_denied'
+            '&error_description=[redacted]&state=[redacted] HTTP/1.1" 400 -',
+        ),
+        (
+            '"GET /unknown HTTP/1.1" 404 -',
+            '"GET /unknown HTTP/1.1" 404 -',
+        ),
+    ],
+)
+def test_redact_request_log(message, expected):
+    assert test_module._redact_request_log(message) == expected
+
+
+def test_callback_debug_log_redacts_query(running_server, caplog):
+    running_server.expect_state("expected-state")
+    with caplog.at_level(logging.DEBUG, logger="obi_auth.server"):
+        httpx2.get(f"{running_server.redirect_uri}?code=secret-code&state=expected-state")
+
+    joined = "\n".join(caplog.messages)
+    assert "secret-code" not in joined
+    assert "expected-state" not in joined
+    assert "code=[redacted]" in joined
+    assert "state=[redacted]" in joined


### PR DESCRIPTION
## Summary
- Document that `get-token` prints a live access token, prefer piping, and avoid passing JWTs as `decode-token` arguments.
- Stop logging the PKCE authorize URL at INFO (it includes `state` and `code_challenge`); log only that the browser is opening.
- Redact `code`, `state`, and `error_description` in local-callback DEBUG access logs.