### PR TITLE
Add auth-manager offline vault token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ from obi_auth import get_token
 access_token = get_token(environment="staging")
 access_token = get_token(environment="staging", token_provider="auth_manager")
 
+# Offline vault (implies auth_manager; Keycloak offline_access consent), then mint:
+access_token = get_token(
+    environment="staging",
+    offline=True,
+)
+
 # Mint from an existing auth-manager persistent id (e.g. obi-one launch scripts):
 access_token = get_token(
     environment="staging",
@@ -67,6 +73,7 @@ Authenticate and print the access token to stdout. Output is a single token stri
 obi-auth get-token
 obi-auth get-token -e production -m daf
 obi-auth get-token -p auth_manager
+obi-auth get-token --offline
 obi-auth get-token -m persistent_token --persistent-token-id <uuid>
 obi-auth get-token --force-refresh
 ```
@@ -77,6 +84,7 @@ obi-auth get-token --force-refresh
 | `-m`, `--auth-mode` | Authentication method: `pkce` (default), `daf`, or `persistent_token` |
 | `-p`, `--token-provider` | Token issuer: `keycloak` (default) or `auth_manager` |
 | `--persistent-token-id` | Persistent token id (required when `--auth-mode persistent_token`) |
+| `--offline` | Offline vault flow (implies `-p auth_manager`): exchange, consent, mint |
 | `--force-refresh` | Clear the cached token and authenticate again |
 
 ### `decode-token`
@@ -86,6 +94,7 @@ Decode a JWT and print the payload as indented JSON. Pass the token as an argume
 ```sh
 obi-auth decode-token eyJhbGciOi...
 obi-auth get-token | obi-auth decode-token
+obi-auth get-token --offline | obi-auth decode-token
 obi-auth get-token | obi-auth decode-token | jq -r '.sub'
 ```
 
@@ -97,6 +106,7 @@ Authenticate, fetch user info from Keycloak, and print the result as indented JS
 obi-auth get-user-info
 obi-auth get-user-info -e production -m daf
 obi-auth get-user-info -p auth_manager
+obi-auth get-user-info --offline
 obi-auth get-user-info --force-refresh
 obi-auth get-user-info | jq -r '.sub'
 ```
@@ -107,6 +117,7 @@ obi-auth get-user-info | jq -r '.sub'
 | `-m`, `--auth-mode` | Authentication method: `pkce` (default), `daf`, or `persistent_token` |
 | `-p`, `--token-provider` | Token issuer: `keycloak` (default) or `auth_manager` |
 | `--persistent-token-id` | Persistent token id (required when `--auth-mode persistent_token`) |
+| `--offline` | Offline vault flow (implies `-p auth_manager`): exchange, consent, mint |
 | `--force-refresh` | Clear the cached token and authenticate again |
 
 ### Global options

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ obi-auth is a library for retrieving Keycloak access tokens interactively. It he
 > [!CAUTION]
 > obi-auth is designed to be used interactively and should not be used within a service or application.
 
+## Documentation
+
+Detailed flow docs (vault ids, lifecycles, HTTP calls, diagrams, and `get_token()` examples) live in **[docs/](docs/README.md)**.
+
 ## Installation
 
 ### Basic Installation

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,40 @@
+# obi-auth documentation
+
+This directory describes how **obi-auth** obtains tokens from Keycloak and, optionally, from **auth-manager** (the token vault service).
+
+> [!CAUTION]
+> obi-auth is for interactive developer / tester use. Do not embed it as a long-running service identity.
+
+## Contents
+
+| Document | Topic |
+| --- | --- |
+| [Overview](overview.md) | Actors, environments, and how pieces fit together |
+| [`get_token()`](get-token.md) | Parameter matrix and which flow each combination runs |
+| [Vault & lifecycles](vault-and-lifecycles.md) | Refresh vs offline vault ids, expiry, reminting |
+| [HTTP reference](http-api.md) | Requests obi-auth makes (paths, headers, responses) |
+| [PKCE flow](flows/pkce.md) | Browser login via local callback |
+| [Device auth (DAF)](flows/daf.md) | Device code login |
+| [Session vault](flows/session-vault.md) | `token_provider=auth_manager` (token-exchange + mint) |
+| [Offline vault](flows/offline-vault.md) | `offline=True` (consent + offline id + mint) |
+| [Persistent token](flows/persistent-token.md) | Mint from a known vault uuid |
+
+## Quick map
+
+```mermaid
+flowchart TD
+  A["get_token(...)"] --> B{auth_mode?}
+  B -->|persistent_token| C["Mint from persistent_token_id"]
+  B -->|pkce / daf| D{offline?}
+  D -->|yes| E["Implies auth_manager"]
+  D -->|no| F{token_provider?}
+  F -->|keycloak| G["Return Keycloak access token"]
+  F -->|auth_manager| H["Token-exchange + mint session vault AT"]
+  E --> I["Token-exchange + mint session AT"]
+  I --> J["Upgrade to offline vault + mint"]
+```
+
+## Related services
+
+- **Keycloak** — identity provider; issues access / refresh / offline tokens.
+- **auth-manager** — encrypts refresh/offline tokens in a Postgres vault and mints fresh access tokens. Upstream docs live in the auth-manager repository (`README.md`).

--- a/docs/flows/daf.md
+++ b/docs/flows/daf.md
@@ -1,0 +1,52 @@
+# Flow: Device Authorization (DAF)
+
+Useful when the machine running obi-auth cannot easily complete a localhost redirect (SSH, remote IDE). The user approves on another device.
+
+## `get_token()`
+
+```python
+from obi_auth import get_token
+
+token = get_token(environment="staging", auth_mode="daf")
+```
+
+CLI: `obi-auth get-token -m daf`
+
+Prompts (verification URL) are written to **stderr**; the access token is still the only stdout line when using the CLI.
+
+## Steps
+
+1. `POST` Keycloak device auth endpoint with `client_id` → `device_code`, `user_code`, `verification_uri_complete`, `interval`, `expires_in`.
+2. Show the verification URL to the user (and open it when possible).
+3. Poll token endpoint with `grant_type=urn:ietf:params:oauth:grant-type:device_code` until success or timeout (`expires_in / interval` attempts).
+4. Cache and return `access_token`.
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant OA as obi-auth
+  participant KC as Keycloak
+
+  OA->>KC: POST /auth/device
+  KC-->>OA: device_code + verification_uri_complete
+  OA->>User: show / open URL (stderr)
+  User->>KC: approve device
+  loop every interval until expires_in
+    OA->>KC: POST /token (device_code)
+    KC-->>OA: authorization_pending or access_token
+  end
+  OA-->>User: return access_token
+```
+
+## Vault ids
+
+None for `token_provider=keycloak`.
+
+## With auth-manager
+
+```python
+get_token(auth_mode="daf", token_provider="auth_manager")
+get_token(auth_mode="daf", offline=True)
+```
+
+Same vault behaviour as the PKCE-based session/offline docs; only the Keycloak login step changes.

--- a/docs/flows/offline-vault.md
+++ b/docs/flows/offline-vault.md
@@ -1,0 +1,94 @@
+# Flow: Offline vault (`offline=True`)
+
+Upgrades from a session (REFRESH) vault mint to an **OFFLINE** vault id (Keycloak `offline_access`), then mints an access token from that offline id. Intended for longer-lived reminting after the interactive session ends.
+
+## `get_token()`
+
+```python
+from obi_auth import get_token
+
+token = get_token(environment="staging", offline=True)
+# implies token_provider="auth_manager"
+# optional: auth_mode="daf"
+```
+
+CLI: `obi-auth get-token --offline`
+
+Consent / status messages go to **stderr** so stdout stays a single JWT for piping.
+
+## Steps
+
+1. **Login** — public-client Keycloak AT (PKCE or DAF).
+2. **Exchange** — `POST /token-exchange` → REFRESH uuid (upsert).
+3. **Mint session AT** — `POST /access-token` with REFRESH uuid (Bearer for later offline calls).
+4. **Resolve offline id** — `POST /offline-token-id` with that session AT:
+   - **404** → first-time for this session: run consent (step 5), then poll again.
+   - **200** → `{ "data": { "persistent_token_id": "<new-offline-uuid>" } }`  
+     auth-manager **always inserts a new OFFLINE row** (linked via `attributes.from` to a prior offline entry for the session).
+5. **Consent (only if 404)**  
+   - `GET /offline-token` → `consent_url`  
+   - Print URL + open browser  
+   - User grants `offline_access` at Keycloak  
+   - Keycloak hits auth-manager `GET /offline-token/callback` (stores first OFFLINE row)  
+   - obi-auth polls `POST /offline-token-id` every 2s up to 300s  
+6. **Mint offline AT** — `POST /access-token` with the offline uuid.
+7. Cache under `{auth_mode}_auth_manager_offline` (separate from session cache).
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant OA as obi-auth
+  participant KC as Keycloak
+  participant AM as auth-manager
+
+  OA->>OA: PKCE/DAF → public AT
+  OA->>AM: POST /token-exchange
+  AM-->>OA: refresh-uuid
+  OA->>AM: POST /access-token (refresh-uuid)
+  AM-->>OA: session AT
+
+  OA->>AM: POST /offline-token-id (Bearer session AT)
+  alt 404 — no offline yet
+    OA->>AM: GET /offline-token
+    AM-->>OA: consent_url
+    OA->>User: open consent (stderr)
+    User->>KC: grant offline_access
+    KC->>AM: /offline-token/callback
+    AM->>AM: store OFFLINE row A
+    loop poll ≤ 300s
+      OA->>AM: POST /offline-token-id
+    end
+  end
+  AM->>AM: store OFFLINE row B (from prior)
+  AM-->>OA: persistent_token_id = offline-uuid-B
+  OA->>AM: POST /access-token (offline-uuid-B)
+  AM-->>OA: offline-backed AT
+  Note over OA: cache offline-uuid-B only
+```
+
+## Vault ids
+
+| Id | When | Cached by obi-auth? |
+| --- | --- | --- |
+| REFRESH uuid from token-exchange | Always in this flow | No (only used transiently) |
+| OFFLINE row from consent callback | First consent for session | No (obi-auth does not read callback header) |
+| OFFLINE uuid from `POST /offline-token-id` | Every successful upgrade | **Yes** |
+
+So after a successful offline run you typically have **at least two** vault rows (REFRESH + OFFLINE), and often **two OFFLINE rows** (callback + clone from `/offline-token-id`).
+
+## Lifecycle
+
+| Artifact | Behaviour |
+| --- | --- |
+| Returned access token | Short-lived JWT; reminted from cached offline uuid |
+| Offline vault id | Kept locally forever until remint fails or `force_refresh` |
+| Keycloak offline token | Survives interactive logout per Keycloak policy; revoke via auth-manager `DELETE /offline-token-id` (not wrapped by obi-auth) |
+
+## Implementation map
+
+| Step | Code |
+| --- | --- |
+| Exchange + session mint | `auth_manager_exchange_token` |
+| Offline upgrade | `auth_manager_upgrade_to_offline_token` |
+| Consent wait | `auth_manager_request_and_await_offline_consent` |
+| Orchestration | `_get_auth_manager_token(..., offline=True)` with separate try/except around upgrade |

--- a/docs/flows/persistent-token.md
+++ b/docs/flows/persistent-token.md
@@ -1,0 +1,61 @@
+# Flow: Persistent token id
+
+Mint an access token from a vault UUID you already have (REFRESH or OFFLINE). No Keycloak login and no token-exchange. Used by callers such as launch scripts that were handed an id out-of-band.
+
+## `get_token()`
+
+```python
+from obi_auth import get_token
+
+token = get_token(
+    environment="staging",
+    auth_mode="persistent_token",
+    persistent_token_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+)
+```
+
+CLI:
+
+```sh
+obi-auth get-token -m persistent_token --persistent-token-id <uuid>
+```
+
+`token_provider` and `offline` are ignored for this mode.
+
+## Steps
+
+1. Require `persistent_token_id`.
+2. If local cache for that id has a valid AT → return it.
+3. If AT expired but id is known → `POST /access-token` with header `id: <uuid>`.
+4. Otherwise mint once and cache under a storage key equal to the uuid string.
+
+```mermaid
+sequenceDiagram
+  participant Caller
+  participant OA as obi-auth
+  participant AM as auth-manager
+  participant KC as Keycloak
+
+  Caller->>OA: get_token(auth_mode=persistent_token, id=…)
+  alt cache hit
+    OA-->>Caller: access_token
+  else remint / cold
+    OA->>AM: POST /access-token<br/>id: uuid
+    AM->>KC: refresh or offline grant
+    KC-->>AM: access_token
+    AM-->>OA: data.access_token
+    OA-->>Caller: access_token
+  end
+```
+
+## Vault ids
+
+Does **not** create a vault id. The uuid must already exist in auth-manager (session REFRESH or OFFLINE). Wrong/revoked ids → mint failure → `ClientError`.
+
+## Lifecycle
+
+Same remint rules as other auth-manager paths: access token JWT expires; vault id is reused until Keycloak/auth-manager rejects it.
+
+## Security note
+
+Anyone who can read the uuid can mint tokens. Prefer injecting ids via a secret channel; do not commit them.

--- a/docs/flows/pkce.md
+++ b/docs/flows/pkce.md
@@ -1,0 +1,56 @@
+# Flow: PKCE (Keycloak)
+
+Default `auth_mode` for interactive desktop use.
+
+## `get_token()`
+
+```python
+from obi_auth import get_token
+
+# Returns a Keycloak access token (azp = public client)
+token = get_token(environment="staging")
+# same as:
+token = get_token(auth_mode="pkce", token_provider="keycloak")
+```
+
+CLI: `obi-auth get-token`
+
+## Steps
+
+1. Start a localhost HTTP callback server (ephemeral port).
+2. Generate PKCE `code_verifier` / `code_challenge` and OAuth `state`.
+3. Open the system browser to Keycloak authorize URL (`scope=openid`, `code_challenge_method=S256`, default `kc_idp_hint=github`).
+4. User signs in; Keycloak redirects to `http://127.0.0.1:<port>/callback?code=…&state=…`.
+5. Server verifies `state`, returns `code` to the client.
+6. `POST` token endpoint with authorization code + `code_verifier`.
+7. Cache and return `access_token`.
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant OA as obi-auth
+  participant Local as localhost callback
+  participant KC as Keycloak
+
+  OA->>Local: bind 127.0.0.1:ephemeral
+  OA->>User: open authorize URL (PKCE + state)
+  User->>KC: login
+  KC->>Local: redirect ?code&state
+  Local-->>OA: authorization code
+  OA->>KC: POST /token (code + verifier)
+  KC-->>OA: access_token
+  OA-->>User: return access_token
+```
+
+## Vault ids
+
+None. No auth-manager calls.
+
+## Lifecycle
+
+- Access token: JWT `exp` (cached until near expiry).
+- On expiry / `force_refresh`: full browser login again.
+
+## Combined with auth-manager
+
+PKCE is also the default login step before session or offline vault flows when `auth_mode="pkce"`.

--- a/docs/flows/session-vault.md
+++ b/docs/flows/session-vault.md
@@ -1,0 +1,78 @@
+# Flow: Session vault (`token_provider=auth_manager`)
+
+Registers a **REFRESH** vault entry via token-exchange, then mints an access token from that id. Suitable for short/medium interactive work while the Keycloak session remains valid.
+
+## `get_token()`
+
+```python
+from obi_auth import get_token
+
+token = get_token(
+    environment="staging",
+    token_provider="auth_manager",
+)
+# optional: auth_mode="daf"
+```
+
+CLI: `obi-auth get-token -p auth_manager`
+
+## Steps
+
+1. Obtain a **public-client** Keycloak access token (PKCE or DAF).
+2. `POST /api/auth-manager/v1/token-exchange`  
+   `Authorization: Bearer <public AT>`  
+   → `{ "data": { "id": "<refresh-uuid>" } }`  
+   auth-manager exchanges with Keycloak for a confidential-client refresh token and **upserts** a REFRESH row (same uuid for same user+session).
+3. `POST /api/auth-manager/v1/access-token`  
+   header `id: <refresh-uuid>`  
+   → `{ "data": { "access_token", "expires_in" } }`
+4. Cache encrypted AT + vault id under key `{auth_mode}_auth_manager`.
+5. Return the access token.
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant OA as obi-auth
+  participant KC as Keycloak
+  participant AM as auth-manager
+  participant Vault as auth_vault
+
+  OA->>User: PKCE or DAF login
+  OA->>KC: public-client access_token
+  OA->>AM: POST /token-exchange<br/>Bearer public AT
+  AM->>KC: grant_type=token-exchange<br/>requested_token_type=refresh_token
+  KC-->>AM: confidential refresh_token
+  AM->>Vault: upsert REFRESH (user_id, sid)
+  AM-->>OA: data.id = refresh-uuid
+  OA->>AM: POST /access-token<br/>id: refresh-uuid
+  AM->>Vault: decrypt REFRESH
+  AM->>KC: refresh grant
+  KC-->>AM: access_token + expires_in
+  AM-->>OA: data.access_token
+  Note over OA: cache refresh-uuid + AT
+```
+
+## Vault ids created / reused
+
+| Id | Type | Behaviour |
+| --- | --- | --- |
+| `data.id` from token-exchange | REFRESH | **Reused** on upsert for the same Keycloak session; new session → new row |
+
+Only this REFRESH id is cached by obi-auth for this flow.
+
+## Lifecycle
+
+| Event | Behaviour |
+| --- | --- |
+| AT still valid in local cache | Return cached AT |
+| AT expired | Remint with same refresh-uuid (`POST /access-token`) |
+| Remint fails (session dead, revoked, …) | Clear cache → login + exchange again |
+| `force_refresh=True` | Clear cache → full flow |
+
+## Implementation map
+
+| Step | Code |
+| --- | --- |
+| Login | `pkce_authenticate` / `daf_authenticate` |
+| Exchange + mint | `auth_manager_exchange_token` → `_auth_manager_exchange_persistent_id` + `auth_manager_mint_access_token` |
+| Orchestration | `_get_auth_manager_token(..., offline=False)` |

--- a/docs/get-token.md
+++ b/docs/get-token.md
@@ -1,0 +1,105 @@
+# `get_token()` reference
+
+```python
+from obi_auth import get_token
+
+get_token(
+    *,
+    environment="staging",          # or "production"
+    auth_mode="pkce",               # "pkce" | "daf" | "persistent_token"
+    token_provider="keycloak",      # "keycloak" | "auth_manager"
+    force_refresh=False,
+    persistent_token_id=None,       # required for auth_mode="persistent_token"
+    offline=False,                  # implies token_provider="auth_manager"
+) -> str
+```
+
+Returns a single **access token** string.
+
+## Decision matrix
+
+| Call | Login | auth-manager | Vault id used | Local cache key (typical) |
+| --- | --- | --- | --- | --- |
+| `get_token()` | PKCE | no | — | `pkce_keycloak` |
+| `get_token(auth_mode="daf")` | Device | no | — | `daf_keycloak` |
+| `get_token(token_provider="auth_manager")` | PKCE | exchange + mint | **REFRESH** | `pkce_auth_manager` |
+| `get_token(auth_mode="daf", token_provider="auth_manager")` | Device | exchange + mint | **REFRESH** | `daf_auth_manager` |
+| `get_token(offline=True)` | PKCE | exchange → upgrade offline → mint | **OFFLINE** | `pkce_auth_manager_offline` |
+| `get_token(auth_mode="daf", offline=True)` | Device | same as above | **OFFLINE** | `daf_auth_manager_offline` |
+| `get_token(auth_mode="persistent_token", persistent_token_id=…)` | none | mint only | whatever that uuid is | keyed by the uuid |
+
+Notes:
+
+- `offline=True` forces `token_provider=auth_manager` even if you pass `keycloak`.
+- `auth_mode="persistent_token"` ignores `token_provider` and `offline`.
+- `force_refresh=True` clears the matching local cache entry, then runs the full flow again.
+
+## Equivalent CLI
+
+| Python | CLI |
+| --- | --- |
+| `get_token()` | `obi-auth get-token` |
+| `get_token(token_provider="auth_manager")` | `obi-auth get-token -p auth_manager` |
+| `get_token(offline=True)` | `obi-auth get-token --offline` |
+| `get_token(auth_mode="daf")` | `obi-auth get-token -m daf` |
+| `get_token(auth_mode="persistent_token", persistent_token_id=id)` | `obi-auth get-token -m persistent_token --persistent-token-id id` |
+
+Stdout is **only** the access token (interactive prompts go to stderr), so piping works:
+
+```sh
+obi-auth get-token --offline | obi-auth decode-token
+```
+
+## Examples
+
+### Keycloak only
+
+```python
+from obi_auth import get_token
+
+# Browser PKCE → Keycloak access token
+token = get_token(environment="staging")
+
+# Device flow (good for SSH / headless with a second device)
+token = get_token(environment="staging", auth_mode="daf")
+```
+
+### Session vault (auth-manager REFRESH)
+
+```python
+token = get_token(
+    environment="staging",
+    token_provider="auth_manager",
+)
+# Under the hood: PKCE → POST /token-exchange → POST /access-token
+```
+
+### Offline vault
+
+```python
+token = get_token(
+    environment="staging",
+    offline=True,
+)
+# Under the hood: PKCE → exchange → mint session AT →
+#   POST /offline-token-id (or consent + poll) → POST /access-token
+```
+
+### Known vault id (e.g. launch scripts)
+
+```python
+token = get_token(
+    environment="staging",
+    auth_mode="persistent_token",
+    persistent_token_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+)
+# Under the hood: POST /access-token with header id=<uuid>
+```
+
+## Caching behaviour (all auth-manager paths)
+
+1. If a non-expired access token is in the local cache → return it.
+2. If the access token expired but a vault id is still stored → `POST /access-token` (remint).
+3. If remint fails → clear local cache → run the full flow again (login / exchange / consent as needed).
+
+Keycloak-only paths cache only the access token; when it expires you must log in again (no remint).

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -1,0 +1,111 @@
+# HTTP API reference (what obi-auth calls)
+
+Base URL used by this library:
+
+```text
+{domain}/api/auth-manager/v1
+```
+
+| Environment | `{domain}` |
+| --- | --- |
+| staging | `https://staging.cell-a.openbraininstitute.org` |
+| production | `https://cell-a.openbraininstitute.org` |
+
+Keycloak base:
+
+```text
+{domain}/auth/realms/SBO
+```
+
+Success bodies from auth-manager are wrapped as `{ "data": … }`.
+
+---
+
+## Keycloak (public client)
+
+### Authorization code + PKCE
+
+1. Browser opens `{keycloak}/protocol/openid-connect/auth` with `client_id`, `redirect_uri` (local server), `code_challenge`, `state`, `scope=openid`, …
+2. Local callback receives `?code=&state=`
+3. `POST {keycloak}/protocol/openid-connect/token` with `grant_type=authorization_code`, `code_verifier`, …
+
+### Device authorization (DAF)
+
+1. `POST {keycloak}/protocol/openid-connect/auth/device` with `client_id`
+2. Poll `POST {keycloak}/protocol/openid-connect/token` with `grant_type=urn:ietf:params:oauth:grant-type:device_code`
+
+### User info
+
+`GET {keycloak}/protocol/openid-connect/userinfo` with `Authorization: Bearer <access_token>` (used by `get_user_info`).
+
+---
+
+## auth-manager endpoints used by obi-auth
+
+### `POST /token-exchange`
+
+**When:** `token_provider=auth_manager` or `offline=True` (after Keycloak login).
+
+| | |
+| --- | --- |
+| Auth | `Authorization: Bearer <public-client access token>` |
+| Body | none |
+| **200** | `{ "data": { "id": "<uuid>" } }` — REFRESH vault id (upsert for user+session) |
+| Errors | 401 invalid Bearer; 502 Keycloak/DB failures |
+
+Side effect: Keycloak standard token exchange as confidential client → encrypt/store **REFRESH**.
+
+### `POST /access-token`
+
+**When:** after exchange; after offline id; remint from cache; `auth_mode=persistent_token`.
+
+| | |
+| --- | --- |
+| Auth | none (possession of id) |
+| Headers | `id: <persistent-token-uuid>` |
+| **200** | `{ "data": { "access_token": "<jwt>", "expires_in": <int> } }` |
+| **404** | unknown id |
+
+Side effect: decrypt vault row → Keycloak refresh/offline grant → return AT. May rotate stored REFRESH ciphertext when Keycloak returns a refresh-type RT.
+
+obi-auth only keeps `data.access_token` (plus the id it already knows).
+
+### `POST /offline-token-id`
+
+**When:** offline upgrade after a session vault access token exists.
+
+| | |
+| --- | --- |
+| Auth | `Authorization: Bearer <access token>` (session vault AT from mint) |
+| Body | none |
+| **200** | `{ "data": { "persistent_token_id": "<uuid>", "session_state_id": "…" } }` |
+| **404** | no OFFLINE row for this Bearer’s Keycloak session yet |
+
+Side effect: finds an existing OFFLINE for the session, asks Keycloak for an offline token (often the same material), **`store()` inserts a new OFFLINE row** with `attributes.from` pointing at the prior entry, returns the **new** uuid.
+
+### `GET /offline-token`
+
+**When:** `POST /offline-token-id` returned 404.
+
+| | |
+| --- | --- |
+| Auth | `Authorization: Bearer <session access token>` |
+| **200** | `{ "data": { "consent_url": "https://…", "session_state_id": "…", "message": "…" } }` |
+
+Side effect: builds Keycloak auth URL with `scope` including `offline_access` and an ack-state JWT. obi-auth prints the URL (stderr), opens a browser, then polls `POST /offline-token-id`.
+
+Consent completion is handled by auth-manager’s `GET /offline-token/callback` (not called by obi-auth directly): Keycloak redirects there with `code`/`state`; auth-manager stores the first OFFLINE row and redirects the browser to a client feedback page.
+
+---
+
+## Endpoints auth-manager exposes but obi-auth does not call
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/refresh-token` | Store a confidential-client refresh token directly |
+| `POST` | `/refresh-token-id` | Resolve/rotate REFRESH id from Bearer session |
+| `DELETE` | `/offline-token-id` | Revoke offline vault row (+ maybe KC offline session) |
+| `GET` | `/validate-token` | Introspect Bearer |
+| `GET` | `/offline-token/callback` | Keycloak redirect target after consent |
+
+See the auth-manager service README for those flows (NextAuth / frontend).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,65 @@
+# Overview
+
+## Actors
+
+| Actor | Role |
+| --- | --- |
+| **User** | Completes browser or device login (and offline consent when asked). |
+| **obi-auth** | Interactive Python / CLI client (public Keycloak client `obi-entitysdk-auth` by default). |
+| **Keycloak** | Issues OIDC tokens for the realm (e.g. `SBO`). |
+| **auth-manager** | Vault service: stores encrypted Keycloak refresh/offline tokens; mints access tokens via Keycloak. |
+| **Local disk cache** | Encrypted token files under `~/.config/obi-auth/` (or `OBI_AUTH_CONFIG_DIR`). |
+
+## Environments
+
+`environment` selects staging vs production domain prefixes used by obi-auth:
+
+| Environment | Domain used by obi-auth |
+| --- | --- |
+| `staging` (default) | `https://staging.cell-a.openbraininstitute.org` |
+| `production` | `https://cell-a.openbraininstitute.org` |
+
+Keycloak URLs are under `/auth/realms/SBO/...`.  
+auth-manager URLs used by obi-auth are under `/api/auth-manager/v1/...` (gateway path; the service itself mounts routes at `/v1/...`).
+
+## Two layers of tokens
+
+```mermaid
+flowchart LR
+  subgraph Keycloak
+    KAT["Access token JWT<br/>short-lived"]
+    KRT["Refresh token<br/>session-bound"]
+    KOT["Offline token<br/>offline_access"]
+  end
+
+  subgraph AuthManagerVault["auth-manager vault"]
+    RID["REFRESH row<br/>persistent id UUID"]
+    OID["OFFLINE row<br/>persistent id UUID"]
+  end
+
+  subgraph ObiAuth["obi-auth returns"]
+    OUT["access_token: str"]
+  end
+
+  KAT -->|token-exchange| KRT
+  KRT --> RID
+  KOT --> OID
+  RID -->|POST /access-token| OUT
+  OID -->|POST /access-token| OUT
+  KAT -->|token_provider=keycloak| OUT
+```
+
+**obi-auth always returns an access token string** (a JWT). When using auth-manager it also caches a **persistent vault id** so it can remint after the access token expires without a full login (as long as the vaulted Keycloak token is still valid).
+
+## Why auth-manager exists for obi-auth
+
+obi-auth authenticates as a **public** Keycloak client. It cannot hold the confidential client secret used by apps like the core web app. auth-manager’s `POST /token-exchange` takes the public-client access token, performs Keycloak **standard token exchange** as the confidential client, stores the resulting **refresh** token in the vault, and returns a UUID. Later `POST /access-token` with that UUID yields a fresh access token minted through Keycloak.
+
+Offline access adds a second vault type (`OFFLINE`) backed by Keycloak’s `offline_access` scope, so jobs can remint after the user’s interactive session ends.
+
+## What this library does *not* do
+
+- It does not implement auth-manager’s NextAuth / direct `POST /refresh-token` path (confidential client already has a refresh token).
+- It does not call `DELETE /offline-token-id` (revocation).
+- It does not call `POST /refresh-token-id` (resolve refresh id by Bearer session).
+- It does not run as a background service identity.

--- a/docs/vault-and-lifecycles.md
+++ b/docs/vault-and-lifecycles.md
@@ -1,0 +1,93 @@
+# Vault ids and lifecycles
+
+auth-manager stores Keycloak tokens in Postgres (`auth_vault`), encrypted at rest (AES-256-CBC). Clients never see the raw refresh/offline string; they hold a **persistent token id** (UUID) and call `POST /access-token` with header `id: <uuid>`.
+
+## Vault row types
+
+| `token_type` | Keycloak material | Uniqueness | Typical creator |
+| --- | --- | --- | --- |
+| **REFRESH** | Confidential-client refresh token (`typ` ≈ Refresh) | One row per `(user_id, session_state_id)` — **upsert** reuses the same UUID | `POST /token-exchange`, `POST /refresh-token`, … |
+| **OFFLINE** | Offline token (`offline_access`; still delivered as `refresh_token` in KC responses) | **Many rows** allowed; each `store()` inserts a **new** UUID | Consent callback; `POST /offline-token-id` clones |
+
+```mermaid
+flowchart TB
+  subgraph Session["Session-bound REFRESH"]
+    S1["Same user + same Keycloak sid"]
+    S2["Upsert → same persistent id"]
+    S1 --> S2
+  end
+
+  subgraph Offline["OFFLINE"]
+    O1["Consent callback → new id"]
+    O2["POST /offline-token-id → always new id<br/>attributes.from = prior entry"]
+    O1 --> O2
+  end
+```
+
+## What expires?
+
+| Artifact | Expires? | Who decides |
+| --- | --- | --- |
+| **Access token** returned by `get_token` | **Yes** — JWT `exp` (often ~1 hour) | Keycloak client/realm policy |
+| **obi-auth local cache of access token** | Yes — Fernet TTL from JWT `exp` minus `EPSILON_TOKEN_TTL_SECONDS` (60s) | obi-auth |
+| **REFRESH vault row** | No local TTL column; dies when Keycloak refresh is invalid / session ends | Keycloak |
+| **OFFLINE vault row** | No local TTL column; dies when Keycloak offline token is revoked/invalid | Keycloak |
+| **Persistent id UUID** | Lives until vault delete / remint failure | auth-manager DB |
+
+Vault rows do **not** have an expiry timestamp in auth-manager. When Keycloak rejects a refresh/offline grant, `POST /access-token` fails (typically surfaced as an HTTP error → obi-auth clears cache and re-auths).
+
+## Two ids after a full offline first run
+
+A cold `get_token(offline=True)` typically leaves **both**:
+
+1. A **REFRESH** id from `POST /token-exchange` (upsert for that session). Used only to mint a short-lived access token that authorizes offline endpoints.
+2. An **OFFLINE** id from `POST /offline-token-id` (always a new insert; may also have created another OFFLINE row in the consent callback). **This** is what obi-auth caches under `*_auth_manager_offline`.
+
+```mermaid
+sequenceDiagram
+  participant OA as obi-auth
+  participant AM as auth-manager
+  participant KC as Keycloak
+
+  OA->>AM: POST /token-exchange
+  AM->>KC: standard token exchange
+  AM->>AM: upsert REFRESH row
+  AM-->>OA: data.id = refresh-uuid
+
+  OA->>AM: POST /access-token (id=refresh-uuid)
+  AM->>KC: refresh grant
+  AM-->>OA: session access_token
+
+  OA->>AM: POST /offline-token-id (Bearer session AT)
+  alt no OFFLINE for session
+    OA->>AM: GET /offline-token → consent_url
+    Note over OA,KC: user grants offline_access
+    AM->>AM: callback stores OFFLINE row A
+    OA->>AM: poll POST /offline-token-id
+  end
+  AM->>AM: store OFFLINE row B (from A)
+  AM-->>OA: data.persistent_token_id = offline-uuid-B
+
+  OA->>AM: POST /access-token (id=offline-uuid-B)
+  AM-->>OA: offline-backed access_token
+  Note over OA: cache offline-uuid-B + AT
+```
+
+## Remint lifecycle in obi-auth
+
+```mermaid
+stateDiagram-v2
+  [*] --> CheckCache
+  CheckCache --> ReturnAT: AT valid
+  CheckCache --> Remint: AT expired, vault id present
+  CheckCache --> FullFlow: no cache
+  Remint --> ReturnAT: POST /access-token ok
+  Remint --> FullFlow: mint failed (clear cache)
+  FullFlow --> ReturnAT: login / exchange / offline / mint
+```
+
+`force_refresh=True` jumps straight to clearing the local file and running the full flow.
+
+## Possession of the UUID
+
+`POST /access-token` (and offline revoke) authorize by **knowing the vault UUID**. Treat persistent ids like secrets: anyone with the id can mint access tokens until the underlying Keycloak token is invalid or the row is deleted.

--- a/src/obi_auth/cli.py
+++ b/src/obi_auth/cli.py
@@ -61,6 +61,12 @@ def main(log_level: str):
     help="Persistent token id (required when auth-mode is persistent_token)",
 )
 @click.option(
+    "--offline",
+    help="Exchange then upgrade to an offline vault token (implies -p auth_manager)",
+    is_flag=True,
+    default=False,
+)
+@click.option(
     "--force-refresh",
     help="Clear the cached token and authenticate again",
     is_flag=True,
@@ -71,6 +77,7 @@ def get_token(
     auth_mode: AuthMode,
     token_provider: TokenProvider,
     persistent_token_id: str | None,
+    offline: bool,
     force_refresh: bool,
 ):
     """Authenticate, print the token to stdout."""
@@ -79,6 +86,7 @@ def get_token(
         auth_mode=auth_mode,
         token_provider=token_provider,
         persistent_token_id=persistent_token_id,
+        offline=offline,
         force_refresh=force_refresh,
     )
     print(access_token)
@@ -128,6 +136,12 @@ def decode_token(access_token: str | None):
     help="Persistent token id (required when auth-mode is persistent_token)",
 )
 @click.option(
+    "--offline",
+    help="Exchange then upgrade to an offline vault token (implies -p auth_manager)",
+    is_flag=True,
+    default=False,
+)
+@click.option(
     "--force-refresh",
     help="Clear the cached token and authenticate again",
     is_flag=True,
@@ -138,6 +152,7 @@ def get_user_info(
     auth_mode: AuthMode,
     token_provider: TokenProvider,
     persistent_token_id: str | None,
+    offline: bool,
     force_refresh: bool,
 ):
     """Show user info information."""
@@ -146,6 +161,7 @@ def get_user_info(
         auth_mode=auth_mode,
         token_provider=token_provider,
         persistent_token_id=persistent_token_id,
+        offline=offline,
         force_refresh=force_refresh,
     )
     print(json.dumps(obi_auth.get_user_info(access_token, environment=environment), indent=2))

--- a/src/obi_auth/client.py
+++ b/src/obi_auth/client.py
@@ -9,6 +9,7 @@ from obi_auth.cache import AuthManagerTokenCache, TokenCache
 from obi_auth.config import settings
 from obi_auth.exception import AuthFlowError, ClientError, ConfigError, LocalServerError
 from obi_auth.flows.auth_manager import (
+    auth_manager_exchange_for_offline_token,
     auth_manager_exchange_token,
     auth_manager_mint_access_token,
 )
@@ -39,6 +40,7 @@ def get_token(
     token_provider: TokenProvider = TokenProvider.keycloak,
     force_refresh: bool = False,
     persistent_token_id: str | None = None,
+    offline: bool = False,
 ) -> str:
     """Get token.
 
@@ -53,6 +55,9 @@ def get_token(
             Ignored when ``auth_mode`` is ``persistent_token``.
         force_refresh: Clear the cached token and authenticate again.
         persistent_token_id: Required when ``auth_mode`` is ``persistent_token``.
+        offline: Token-exchange then upgrade to an offline vault token (Keycloak
+            ``offline_access`` consent) before minting. Implies
+            ``token_provider=auth_manager``. Ignored for ``persistent_token``.
     """
     auth_mode = AuthMode(auth_mode)
     token_provider = TokenProvider(token_provider)
@@ -69,10 +74,17 @@ def get_token(
             force_refresh=force_refresh,
         )
 
+    if offline:
+        token_provider = TokenProvider.auth_manager
+
+    storage_key = f"{auth_mode}_{token_provider}"
+    if offline:
+        storage_key = f"{storage_key}_offline"
+
     storage = Storage(
         config_dir=settings.config_dir,
         environment=environment,
-        key=f"{auth_mode}_{token_provider}",
+        key=storage_key,
     )
 
     if token_provider == TokenProvider.auth_manager:
@@ -81,6 +93,7 @@ def get_token(
             environment=environment,
             auth_mode=auth_mode,
             force_refresh=force_refresh,
+            offline=offline,
         )
     return _get_keycloak_token(
         storage=storage,
@@ -153,6 +166,7 @@ def _get_auth_manager_token(
     environment: DeploymentEnvironment,
     auth_mode: AuthMode,
     force_refresh: bool,
+    offline: bool = False,
 ) -> str:
     if force_refresh:
         L.debug("Forcing token refresh, clearing cached token")
@@ -170,8 +184,9 @@ def _get_auth_manager_token(
 
     auth_method = _get_auth_method(auth_mode)
     keycloak_token = auth_method(environment=environment)
+    exchange = auth_manager_exchange_for_offline_token if offline else auth_manager_exchange_token
     try:
-        token_info = auth_manager_exchange_token(keycloak_token, environment=environment)
+        token_info = exchange(keycloak_token, environment=environment)
     except AuthFlowError as e:
         raise ClientError("Authentication process failed.") from e
 

--- a/src/obi_auth/client.py
+++ b/src/obi_auth/client.py
@@ -9,9 +9,9 @@ from obi_auth.cache import AuthManagerTokenCache, TokenCache
 from obi_auth.config import settings
 from obi_auth.exception import AuthFlowError, ClientError, ConfigError, LocalServerError
 from obi_auth.flows.auth_manager import (
-    auth_manager_exchange_for_offline_token,
     auth_manager_exchange_token,
     auth_manager_mint_access_token,
+    auth_manager_upgrade_to_offline_token,
 )
 from obi_auth.flows.daf import daf_authenticate
 from obi_auth.flows.pkce import pkce_authenticate
@@ -76,10 +76,9 @@ def get_token(
 
     if offline:
         token_provider = TokenProvider.auth_manager
-
-    storage_key = f"{auth_mode}_{token_provider}"
-    if offline:
-        storage_key = f"{storage_key}_offline"
+        storage_key = f"{auth_mode}_{token_provider}_offline"
+    else:
+        storage_key = f"{auth_mode}_{token_provider}"
 
     storage = Storage(
         config_dir=settings.config_dir,
@@ -184,11 +183,16 @@ def _get_auth_manager_token(
 
     auth_method = _get_auth_method(auth_mode)
     keycloak_token = auth_method(environment=environment)
-    exchange = auth_manager_exchange_for_offline_token if offline else auth_manager_exchange_token
     try:
-        token_info = exchange(keycloak_token, environment=environment)
+        token_info = auth_manager_exchange_token(keycloak_token, environment=environment)
     except AuthFlowError as e:
         raise ClientError("Authentication process failed.") from e
+
+    if offline:
+        try:
+            token_info = auth_manager_upgrade_to_offline_token(token_info, environment=environment)
+        except AuthFlowError as e:
+            raise ClientError("Authentication process failed.") from e
 
     _AUTH_MANAGER_TOKEN_CACHE.set(token_info, storage)
     if token_info.access_token is None:

--- a/src/obi_auth/config.py
+++ b/src/obi_auth/config.py
@@ -38,6 +38,10 @@ class Settings(BaseSettings):
 
     LOCAL_SERVER_TIMEOUT: int = 60
 
+    # Offline consent: poll /offline-token-id until the user finishes Keycloak consent
+    OFFLINE_CONSENT_TIMEOUT_SECONDS: int = 300
+    OFFLINE_CONSENT_POLL_INTERVAL_SECONDS: float = 2.0
+
     def _get_domain_url(self, override_env: DeploymentEnvironment) -> str:
         """Return domain url based on environment."""
         match env := override_env or self.KEYCLOAK_ENV:
@@ -95,6 +99,20 @@ class Settings(BaseSettings):
         """Return auth-manager token exchange endpoint."""
         base_url = self.get_auth_manager_url(override_env=override_env)
         return f"{base_url}/token-exchange"
+
+    def get_auth_manager_offline_token_endpoint(
+        self, override_env: DeploymentEnvironment | None = None
+    ) -> str:
+        """Return auth-manager offline-token consent endpoint."""
+        base_url = self.get_auth_manager_url(override_env=override_env)
+        return f"{base_url}/offline-token"
+
+    def get_auth_manager_offline_token_id_endpoint(
+        self, override_env: DeploymentEnvironment | None = None
+    ) -> str:
+        """Return auth-manager offline-token-id endpoint."""
+        base_url = self.get_auth_manager_url(override_env=override_env)
+        return f"{base_url}/offline-token-id"
 
 
 settings = Settings()

--- a/src/obi_auth/flows/auth_manager.py
+++ b/src/obi_auth/flows/auth_manager.py
@@ -4,6 +4,7 @@ import logging
 import sys
 import webbrowser
 from time import monotonic, sleep
+from typing import TypedDict
 
 import httpx2
 
@@ -18,7 +19,16 @@ from obi_auth.util import is_running_in_notebook
 
 L = logging.getLogger(__name__)
 
-_OFFLINE_CONSENT_MESSAGE = {
+
+class OfflineConsentMessageData(TypedDict):
+    """Data structure for offline consent message content."""
+
+    title: str
+    steps: list[str]
+    url: str
+
+
+_OFFLINE_CONSENT_MESSAGE: OfflineConsentMessageData = {
     "title": "Offline Access Consent Required\n\n",
     "steps": [
         "1. Open the consent URL below\n",

--- a/src/obi_auth/flows/auth_manager.py
+++ b/src/obi_auth/flows/auth_manager.py
@@ -1,6 +1,9 @@
 """Authentication helpers for auth-manager persistent tokens."""
 
 import logging
+import sys
+import webbrowser
+from time import monotonic, sleep
 
 import httpx2
 
@@ -11,8 +14,19 @@ from obi_auth.typedef import (
     DeploymentEnvironment,
     KeycloakTokenInfo,
 )
+from obi_auth.util import is_running_in_notebook
 
 L = logging.getLogger(__name__)
+
+_OFFLINE_CONSENT_MESSAGE = {
+    "title": "Offline Access Consent Required\n\n",
+    "steps": [
+        "1. Open the consent URL below\n",
+        "2. Grant offline access in the browser\n",
+        "3. Return here when done\n\n",
+    ],
+    "url": "Consent URL:\n",
+}
 
 
 def auth_manager_mint_access_token(
@@ -55,3 +69,105 @@ def auth_manager_exchange_token(
         raise AuthFlowError(msg)
 
     return auth_manager_mint_access_token(token_id, environment=environment)
+
+
+def auth_manager_exchange_for_offline_token(
+    token_info: KeycloakTokenInfo, *, environment: DeploymentEnvironment
+) -> AuthManagerTokenInfo:
+    """Token-exchange, then obtain an offline vault id (consent if needed) and mint."""
+    exchanged = auth_manager_exchange_token(token_info, environment=environment)
+    if exchanged.access_token is None:
+        raise AuthFlowError("AuthManager exchange did not return an access token")
+
+    offline_id = auth_manager_get_offline_token_id(exchanged.access_token, environment=environment)
+    if offline_id is None:
+        offline_id = auth_manager_request_and_await_offline_consent(
+            exchanged.access_token, environment=environment
+        )
+
+    return auth_manager_mint_access_token(offline_id, environment=environment)
+
+
+def auth_manager_get_offline_token_id(
+    access_token: str, *, environment: DeploymentEnvironment
+) -> str | None:
+    """Return an offline persistent id for this session, or None if none exists yet."""
+    response = httpx2.post(
+        url=settings.get_auth_manager_offline_token_id_endpoint(override_env=environment),
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    if response.status_code == 404:
+        return None
+    response.raise_for_status()
+    data = response.json()
+    token_id = data.get("data", {}).get("persistent_token_id")
+    if not token_id:
+        msg = f"AuthManager unexpected payload: {data}"
+        L.error(msg)
+        raise AuthFlowError(msg)
+    return str(token_id)
+
+
+def auth_manager_request_offline_consent(
+    access_token: str, *, environment: DeploymentEnvironment
+) -> str:
+    """Start offline consent and return the Keycloak consent URL."""
+    data = (
+        httpx2.get(
+            url=settings.get_auth_manager_offline_token_endpoint(override_env=environment),
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        .raise_for_status()
+        .json()
+    )
+    if not (consent_url := data.get("data", {}).get("consent_url")):
+        msg = f"AuthManager unexpected payload: {data}"
+        L.error(msg)
+        raise AuthFlowError(msg)
+    return consent_url
+
+
+def auth_manager_request_and_await_offline_consent(
+    access_token: str, *, environment: DeploymentEnvironment
+) -> str:
+    """Prompt for offline consent and poll until an offline vault id is available."""
+    consent_url = auth_manager_request_offline_consent(access_token, environment=environment)
+    _display_offline_consent_prompt(consent_url)
+    webbrowser.open(consent_url)
+
+    deadline = monotonic() + settings.OFFLINE_CONSENT_TIMEOUT_SECONDS
+    while monotonic() < deadline:
+        if offline_id := auth_manager_get_offline_token_id(access_token, environment=environment):
+            print("\r   ✓ Offline access granted!", flush=True, file=sys.stderr)
+            return offline_id
+        sleep(settings.OFFLINE_CONSENT_POLL_INTERVAL_SECONDS)
+
+    print("\r   ✗ Offline consent timed out", flush=True, file=sys.stderr)
+    raise AuthFlowError("Offline consent timed out waiting for user approval.")
+
+
+def _display_offline_consent_prompt(consent_url: str) -> None:
+    """Show the offline consent URL on stderr (keep stdout token-only for piping)."""
+    if is_running_in_notebook():
+        try:
+            from rich.console import Console
+            from rich.style import Style
+            from rich.text import Text
+
+            auth_text = Text()
+            auth_text.append(_OFFLINE_CONSENT_MESSAGE["title"], style="bold deep_sky_blue4")
+            for step in _OFFLINE_CONSENT_MESSAGE["steps"]:
+                auth_text.append(step, style="white")
+            auth_text.append(_OFFLINE_CONSENT_MESSAGE["url"], style="dim")
+            link_style = Style(color="deep_sky_blue4", underline=True, link=consent_url)
+            auth_text.append(consent_url, style=link_style)
+            Console(stderr=True).print(auth_text)
+            return
+        except Exception as e:
+            L.warning("Rich is not supported, using fallback: %s", e)
+
+    print(_OFFLINE_CONSENT_MESSAGE["title"], file=sys.stderr)
+    for step in _OFFLINE_CONSENT_MESSAGE["steps"]:
+        print(step, file=sys.stderr)
+    print(_OFFLINE_CONSENT_MESSAGE["url"], file=sys.stderr)
+    print(f"   {consent_url}", file=sys.stderr)

--- a/src/obi_auth/flows/auth_manager.py
+++ b/src/obi_auth/flows/auth_manager.py
@@ -60,10 +60,10 @@ def auth_manager_mint_access_token(
     return AuthManagerTokenInfo(access_token=access_token, persistent_token_id=persistent_token_id)
 
 
-def auth_manager_exchange_token(
+def _auth_manager_exchange_persistent_id(
     token_info: KeycloakTokenInfo, *, environment: DeploymentEnvironment
-) -> AuthManagerTokenInfo:
-    """Exchange a Keycloak access token and mint an auth-manager access token."""
+) -> str:
+    """Exchange a Keycloak access token for a session vault persistent id."""
     exchange_data = (
         httpx2.post(
             url=settings.get_auth_manager_token_exchange_endpoint(override_env=environment),
@@ -78,21 +78,28 @@ def auth_manager_exchange_token(
         L.error(msg)
         raise AuthFlowError(msg)
 
+    return str(token_id)
+
+
+def auth_manager_exchange_token(
+    token_info: KeycloakTokenInfo, *, environment: DeploymentEnvironment
+) -> AuthManagerTokenInfo:
+    """Exchange a Keycloak access token and mint an auth-manager access token."""
+    token_id = _auth_manager_exchange_persistent_id(token_info, environment=environment)
     return auth_manager_mint_access_token(token_id, environment=environment)
 
 
-def auth_manager_exchange_for_offline_token(
-    token_info: KeycloakTokenInfo, *, environment: DeploymentEnvironment
+def auth_manager_upgrade_to_offline_token(
+    token_info: AuthManagerTokenInfo, *, environment: DeploymentEnvironment
 ) -> AuthManagerTokenInfo:
-    """Token-exchange, then obtain an offline vault id (consent if needed) and mint."""
-    exchanged = auth_manager_exchange_token(token_info, environment=environment)
-    if exchanged.access_token is None:
+    """Upgrade a session vault access token to an offline vault token (consent if needed)."""
+    if token_info.access_token is None:
         raise AuthFlowError("AuthManager exchange did not return an access token")
 
-    offline_id = auth_manager_get_offline_token_id(exchanged.access_token, environment=environment)
+    offline_id = auth_manager_get_offline_token_id(token_info.access_token, environment=environment)
     if offline_id is None:
         offline_id = auth_manager_request_and_await_offline_consent(
-            exchanged.access_token, environment=environment
+            token_info.access_token, environment=environment
         )
 
     return auth_manager_mint_access_token(offline_id, environment=environment)

--- a/src/obi_auth/flows/daf.py
+++ b/src/obi_auth/flows/daf.py
@@ -1,6 +1,7 @@
 """Authorization flow module."""
 
 import logging
+import sys
 from time import sleep
 from typing import TypedDict
 
@@ -41,10 +42,14 @@ def daf_authenticate(*, environment: DeploymentEnvironment) -> KeycloakTokenInfo
     _display_auth_prompt(device_info)
 
     if token := _poll_device_code_token(device_info, environment):
-        print("\r   ✓ Authentication completed successfully!", flush=True)
+        print(
+            "\r   ✓ Authentication completed successfully!",
+            flush=True,
+            file=sys.stderr,
+        )
         return KeycloakTokenInfo(access_token=token)
 
-    print("\r   ✗ Authentication failed - timeout reached", flush=True)
+    print("\r   ✗ Authentication failed - timeout reached", flush=True, file=sys.stderr)
     raise AuthFlowError("Polling using device code reached max retries.")
 
 
@@ -121,7 +126,7 @@ def _display_notebook_auth_prompt(device_info: AuthDeviceInfo) -> None:
         link_style = Style(color="deep_sky_blue4", underline=True, link=verification_url)
         auth_text.append(f"{verification_url}", style=link_style)
 
-        Console().print(auth_text)
+        Console(stderr=True).print(auth_text)
 
     except Exception as e:
         L.warning(f"Rich is not supported, using fallback: {e}")
@@ -129,11 +134,11 @@ def _display_notebook_auth_prompt(device_info: AuthDeviceInfo) -> None:
 
 
 def _display_terminal_auth_prompt(device_info: AuthDeviceInfo) -> None:
-    """Display a simple authentication prompt for terminal usage."""
-    print(AUTHENTICATION_MESSAGE_DATA["title"])
+    """Display a simple authentication prompt on stderr (stdout stays token-only)."""
+    print(AUTHENTICATION_MESSAGE_DATA["title"], file=sys.stderr)
 
     for step in AUTHENTICATION_MESSAGE_DATA["steps"]:
-        print(step)
+        print(step, file=sys.stderr)
 
-    print(AUTHENTICATION_MESSAGE_DATA["url"])
-    print(f"   {device_info.verification_uri_complete}")
+    print(AUTHENTICATION_MESSAGE_DATA["url"], file=sys.stderr)
+    print(f"   {device_info.verification_uri_complete}", file=sys.stderr)

--- a/tests/unit/flows/test_auth_manager.py
+++ b/tests/unit/flows/test_auth_manager.py
@@ -202,8 +202,8 @@ def test_auth_manager_exchange_for_offline_token__existing_offline(
         KeycloakTokenInfo(access_token="public-token"),  # noqa: S106
         environment="staging",
     )
-    assert res.access_token == "offline-at"
-    assert res.persistent_token_id == "offline-id"
+    assert res.access_token == "offline-at"  # noqa: S105
+    assert res.persistent_token_id == "offline-id"  # noqa: S105
     mock_get_id.assert_called_once_with("exchanged-at", environment="staging")
     mock_mint.assert_called_once_with("offline-id", environment="staging")
 
@@ -234,7 +234,7 @@ def test_auth_manager_exchange_for_offline_token__needs_consent(
         KeycloakTokenInfo(access_token="public-token"),  # noqa: S106
         environment="staging",
     )
-    assert res.access_token == "offline-at"
+    assert res.access_token == "offline-at"  # noqa: S105
     mock_await.assert_called_once_with("exchanged-at", environment="staging")
     mock_mint.assert_called_once_with("offline-id", environment="staging")
 

--- a/tests/unit/flows/test_auth_manager.py
+++ b/tests/unit/flows/test_auth_manager.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from obi_auth.config import settings
@@ -76,3 +78,201 @@ def test_auth_manager_exchange_token__mint_raises(httpx2_mock):
             KeycloakTokenInfo(access_token="public-token"),  # noqa: S106
             environment="staging",
         )
+
+
+def test_auth_manager_get_offline_token_id(httpx2_mock):
+    httpx2_mock.post(
+        settings.get_auth_manager_offline_token_id_endpoint(override_env="staging")
+    ).respond(json={"data": {"persistent_token_id": "offline-id"}})
+
+    assert (
+        test_module.auth_manager_get_offline_token_id("exchanged-at", environment="staging")
+        == "offline-id"
+    )
+    assert httpx2_mock.calls[0].request.headers["Authorization"] == "Bearer exchanged-at"
+
+
+def test_auth_manager_get_offline_token_id__not_found(httpx2_mock):
+    httpx2_mock.post(
+        settings.get_auth_manager_offline_token_id_endpoint(override_env="staging")
+    ).respond(404, json={"error": "not found"})
+
+    assert (
+        test_module.auth_manager_get_offline_token_id("exchanged-at", environment="staging") is None
+    )
+
+
+def test_auth_manager_get_offline_token_id__unexpected_payload(httpx2_mock):
+    httpx2_mock.post(
+        settings.get_auth_manager_offline_token_id_endpoint(override_env="staging")
+    ).respond(json={"data": {}})
+
+    with pytest.raises(AuthFlowError, match="AuthManager unexpected payload"):
+        test_module.auth_manager_get_offline_token_id("exchanged-at", environment="staging")
+
+
+def test_auth_manager_request_offline_consent(httpx2_mock):
+    httpx2_mock.get(
+        settings.get_auth_manager_offline_token_endpoint(override_env="staging")
+    ).respond(json={"data": {"consent_url": "https://example.com/consent"}})
+
+    assert (
+        test_module.auth_manager_request_offline_consent("exchanged-at", environment="staging")
+        == "https://example.com/consent"
+    )
+    assert httpx2_mock.calls[0].request.headers["Authorization"] == "Bearer exchanged-at"
+
+
+def test_auth_manager_request_offline_consent__unexpected_payload(httpx2_mock):
+    httpx2_mock.get(
+        settings.get_auth_manager_offline_token_endpoint(override_env="staging")
+    ).respond(json={"data": {}})
+
+    with pytest.raises(AuthFlowError, match="AuthManager unexpected payload"):
+        test_module.auth_manager_request_offline_consent("exchanged-at", environment="staging")
+
+
+@patch("obi_auth.flows.auth_manager.webbrowser")
+@patch("obi_auth.flows.auth_manager.sleep")
+@patch("obi_auth.flows.auth_manager._display_offline_consent_prompt")
+@patch(
+    "obi_auth.flows.auth_manager.auth_manager_request_offline_consent",
+    return_value="https://example.com/consent",
+)
+@patch(
+    "obi_auth.flows.auth_manager.auth_manager_get_offline_token_id",
+    side_effect=[None, "offline-id"],
+)
+def test_auth_manager_request_and_await_offline_consent(
+    mock_get_id, mock_request, mock_display, mock_sleep, mock_web
+):
+    assert (
+        test_module.auth_manager_request_and_await_offline_consent(
+            "exchanged-at", environment="staging"
+        )
+        == "offline-id"
+    )
+    mock_request.assert_called_once_with("exchanged-at", environment="staging")
+    mock_display.assert_called_once_with("https://example.com/consent")
+    mock_web.open.assert_called_once_with("https://example.com/consent")
+    mock_sleep.assert_called_once()
+
+
+@patch("obi_auth.flows.auth_manager.webbrowser")
+@patch("obi_auth.flows.auth_manager.sleep")
+@patch("obi_auth.flows.auth_manager.monotonic", side_effect=[0, 1, 999])
+@patch("obi_auth.flows.auth_manager._display_offline_consent_prompt")
+@patch(
+    "obi_auth.flows.auth_manager.auth_manager_request_offline_consent",
+    return_value="https://example.com/consent",
+)
+@patch("obi_auth.flows.auth_manager.auth_manager_get_offline_token_id", return_value=None)
+def test_auth_manager_request_and_await_offline_consent__timeout(
+    mock_get_id, mock_request, mock_display, mock_monotonic, mock_sleep, mock_web
+):
+    with patch.object(settings, "OFFLINE_CONSENT_TIMEOUT_SECONDS", 10):
+        with pytest.raises(AuthFlowError, match="Offline consent timed out"):
+            test_module.auth_manager_request_and_await_offline_consent(
+                "exchanged-at", environment="staging"
+            )
+
+
+@patch(
+    "obi_auth.flows.auth_manager.auth_manager_mint_access_token",
+    return_value=AuthManagerTokenInfo(
+        access_token="offline-at",  # noqa: S106
+        persistent_token_id="offline-id",  # noqa: S106
+    ),
+)
+@patch(
+    "obi_auth.flows.auth_manager.auth_manager_get_offline_token_id",
+    return_value="offline-id",
+)
+@patch(
+    "obi_auth.flows.auth_manager.auth_manager_exchange_token",
+    return_value=AuthManagerTokenInfo(
+        access_token="exchanged-at",  # noqa: S106
+        persistent_token_id="refresh-id",  # noqa: S106
+    ),
+)
+def test_auth_manager_exchange_for_offline_token__existing_offline(
+    mock_exchange, mock_get_id, mock_mint
+):
+    res = test_module.auth_manager_exchange_for_offline_token(
+        KeycloakTokenInfo(access_token="public-token"),  # noqa: S106
+        environment="staging",
+    )
+    assert res.access_token == "offline-at"
+    assert res.persistent_token_id == "offline-id"
+    mock_get_id.assert_called_once_with("exchanged-at", environment="staging")
+    mock_mint.assert_called_once_with("offline-id", environment="staging")
+
+
+@patch(
+    "obi_auth.flows.auth_manager.auth_manager_mint_access_token",
+    return_value=AuthManagerTokenInfo(
+        access_token="offline-at",  # noqa: S106
+        persistent_token_id="offline-id",  # noqa: S106
+    ),
+)
+@patch(
+    "obi_auth.flows.auth_manager.auth_manager_request_and_await_offline_consent",
+    return_value="offline-id",
+)
+@patch("obi_auth.flows.auth_manager.auth_manager_get_offline_token_id", return_value=None)
+@patch(
+    "obi_auth.flows.auth_manager.auth_manager_exchange_token",
+    return_value=AuthManagerTokenInfo(
+        access_token="exchanged-at",  # noqa: S106
+        persistent_token_id="refresh-id",  # noqa: S106
+    ),
+)
+def test_auth_manager_exchange_for_offline_token__needs_consent(
+    mock_exchange, mock_get_id, mock_await, mock_mint
+):
+    res = test_module.auth_manager_exchange_for_offline_token(
+        KeycloakTokenInfo(access_token="public-token"),  # noqa: S106
+        environment="staging",
+    )
+    assert res.access_token == "offline-at"
+    mock_await.assert_called_once_with("exchanged-at", environment="staging")
+    mock_mint.assert_called_once_with("offline-id", environment="staging")
+
+
+@patch(
+    "obi_auth.flows.auth_manager.auth_manager_exchange_token",
+    return_value=AuthManagerTokenInfo(
+        access_token=None,
+        persistent_token_id="refresh-id",  # noqa: S106
+    ),
+)
+def test_auth_manager_exchange_for_offline_token__no_access_token(mock_exchange):
+    with pytest.raises(AuthFlowError, match="did not return an access token"):
+        test_module.auth_manager_exchange_for_offline_token(
+            KeycloakTokenInfo(access_token="public-token"),  # noqa: S106
+            environment="staging",
+        )
+
+
+@patch("obi_auth.flows.auth_manager.is_running_in_notebook", return_value=False)
+def test_display_offline_consent_prompt_terminal(mock_notebook, capsys):
+    test_module._display_offline_consent_prompt("https://example.com/consent")
+    err = capsys.readouterr().err
+    assert "Offline Access Consent Required" in err
+    assert "https://example.com/consent" in err
+
+
+@patch("obi_auth.flows.auth_manager.is_running_in_notebook", return_value=True)
+def test_display_offline_consent_prompt_notebook(mock_notebook):
+    with patch("rich.console.Console") as mock_console:
+        test_module._display_offline_consent_prompt("https://example.com/consent")
+        mock_console.assert_called_once_with(stderr=True)
+        mock_console.return_value.print.assert_called_once()
+
+
+@patch("obi_auth.flows.auth_manager.is_running_in_notebook", return_value=True)
+def test_display_offline_consent_prompt_notebook_fallback(mock_notebook, capsys):
+    with patch("rich.console.Console", side_effect=ImportError("no rich")):
+        test_module._display_offline_consent_prompt("https://example.com/consent")
+    err = capsys.readouterr().err
+    assert "https://example.com/consent" in err

--- a/tests/unit/flows/test_auth_manager.py
+++ b/tests/unit/flows/test_auth_manager.py
@@ -188,18 +188,12 @@ def test_auth_manager_request_and_await_offline_consent__timeout(
     "obi_auth.flows.auth_manager.auth_manager_get_offline_token_id",
     return_value="offline-id",
 )
-@patch(
-    "obi_auth.flows.auth_manager.auth_manager_exchange_token",
-    return_value=AuthManagerTokenInfo(
-        access_token="exchanged-at",  # noqa: S106
-        persistent_token_id="refresh-id",  # noqa: S106
-    ),
-)
-def test_auth_manager_exchange_for_offline_token__existing_offline(
-    mock_exchange, mock_get_id, mock_mint
-):
-    res = test_module.auth_manager_exchange_for_offline_token(
-        KeycloakTokenInfo(access_token="public-token"),  # noqa: S106
+def test_auth_manager_upgrade_to_offline_token__existing_offline(mock_get_id, mock_mint):
+    res = test_module.auth_manager_upgrade_to_offline_token(
+        AuthManagerTokenInfo(
+            access_token="exchanged-at",  # noqa: S106
+            persistent_token_id="refresh-id",  # noqa: S106
+        ),
         environment="staging",
     )
     assert res.access_token == "offline-at"  # noqa: S105
@@ -220,18 +214,12 @@ def test_auth_manager_exchange_for_offline_token__existing_offline(
     return_value="offline-id",
 )
 @patch("obi_auth.flows.auth_manager.auth_manager_get_offline_token_id", return_value=None)
-@patch(
-    "obi_auth.flows.auth_manager.auth_manager_exchange_token",
-    return_value=AuthManagerTokenInfo(
-        access_token="exchanged-at",  # noqa: S106
-        persistent_token_id="refresh-id",  # noqa: S106
-    ),
-)
-def test_auth_manager_exchange_for_offline_token__needs_consent(
-    mock_exchange, mock_get_id, mock_await, mock_mint
-):
-    res = test_module.auth_manager_exchange_for_offline_token(
-        KeycloakTokenInfo(access_token="public-token"),  # noqa: S106
+def test_auth_manager_upgrade_to_offline_token__needs_consent(mock_get_id, mock_await, mock_mint):
+    res = test_module.auth_manager_upgrade_to_offline_token(
+        AuthManagerTokenInfo(
+            access_token="exchanged-at",  # noqa: S106
+            persistent_token_id="refresh-id",  # noqa: S106
+        ),
         environment="staging",
     )
     assert res.access_token == "offline-at"  # noqa: S105
@@ -239,17 +227,13 @@ def test_auth_manager_exchange_for_offline_token__needs_consent(
     mock_mint.assert_called_once_with("offline-id", environment="staging")
 
 
-@patch(
-    "obi_auth.flows.auth_manager.auth_manager_exchange_token",
-    return_value=AuthManagerTokenInfo(
-        access_token=None,
-        persistent_token_id="refresh-id",  # noqa: S106
-    ),
-)
-def test_auth_manager_exchange_for_offline_token__no_access_token(mock_exchange):
+def test_auth_manager_upgrade_to_offline_token__no_access_token():
     with pytest.raises(AuthFlowError, match="did not return an access token"):
-        test_module.auth_manager_exchange_for_offline_token(
-            KeycloakTokenInfo(access_token="public-token"),  # noqa: S106
+        test_module.auth_manager_upgrade_to_offline_token(
+            AuthManagerTokenInfo(
+                access_token=None,
+                persistent_token_id="refresh-id",  # noqa: S106
+            ),
             environment="staging",
         )
 

--- a/tests/unit/flows/test_daf.py
+++ b/tests/unit/flows/test_daf.py
@@ -1,3 +1,4 @@
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -37,7 +38,11 @@ def test_daf_authenticate_success(
     assert result == KeycloakTokenInfo(access_token="test_token")  # noqa: S106
     mock_display_prompt.assert_called_once_with(device_info)
     mock_poll.assert_called_once_with(device_info, DeploymentEnvironment.staging)
-    mock_print.assert_called_with("\r   ✓ Authentication completed successfully!", flush=True)
+    mock_print.assert_called_with(
+        "\r   ✓ Authentication completed successfully!",
+        flush=True,
+        file=sys.stderr,
+    )
 
 
 @patch("obi_auth.flows.daf._poll_device_code_token")
@@ -56,7 +61,11 @@ def test_daf_authenticate_failure(
 
     mock_display_prompt.assert_called_once_with(device_info)
     mock_poll.assert_called_once_with(device_info, DeploymentEnvironment.staging)
-    mock_print.assert_called_with("\r   ✗ Authentication failed - timeout reached", flush=True)
+    mock_print.assert_called_with(
+        "\r   ✗ Authentication failed - timeout reached",
+        flush=True,
+        file=sys.stderr,
+    )
 
 
 def test_device_code_token(httpx2_mock, device_info):
@@ -147,6 +156,7 @@ def test_display_notebook_auth_prompt_success(mock_console, device_info):
 
     test_module._display_notebook_auth_prompt(device_info)
 
+    mock_console.assert_called_once_with(stderr=True)
     mock_console_instance.print.assert_called_once()
 
 
@@ -173,9 +183,9 @@ def test_get_device_url_code(mock_post, device_info):
 
 @patch("builtins.print")
 def test_display_terminal_auth_prompt(mock_print, device_info):
-    """Test _display_terminal_auth_prompt function."""
+    """Test _display_terminal_auth_prompt writes prompts to stderr."""
     test_module._display_terminal_auth_prompt(device_info)
 
-    # Verify print was called for each part of the message
     # title + 3 steps + url + verification_uri_complete = 6 calls
     assert mock_print.call_count == 6
+    assert all(call.kwargs.get("file") is sys.stderr for call in mock_print.call_args_list)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -85,6 +85,7 @@ def test_get_token(mock_token, cli_runner):
         auth_mode=AuthMode.daf,
         token_provider=TokenProvider.keycloak,
         persistent_token_id=None,
+        offline=False,
         force_refresh=False,
     )
 
@@ -96,6 +97,7 @@ def test_get_token(mock_token, cli_runner):
         auth_mode=AuthMode.pkce,
         token_provider=TokenProvider.keycloak,
         persistent_token_id=None,
+        offline=False,
         force_refresh=False,
     )
 
@@ -106,6 +108,7 @@ def test_get_token(mock_token, cli_runner):
         auth_mode=AuthMode.pkce,
         token_provider=TokenProvider.auth_manager,
         persistent_token_id=None,
+        offline=False,
         force_refresh=False,
     )
 
@@ -118,6 +121,29 @@ def test_get_token(mock_token, cli_runner):
         auth_mode=AuthMode.persistent_token,
         token_provider=TokenProvider.keycloak,
         persistent_token_id="pt-1",  # noqa: S106
+        offline=False,
+        force_refresh=False,
+    )
+
+    result = cli_runner.invoke(main, ["get-token", "-p", "auth_manager", "--offline"])
+    assert result.exit_code == 0
+    mock_token.assert_called_with(
+        environment=DeploymentEnvironment.staging,
+        auth_mode=AuthMode.pkce,
+        token_provider=TokenProvider.auth_manager,
+        persistent_token_id=None,
+        offline=True,
+        force_refresh=False,
+    )
+
+    result = cli_runner.invoke(main, ["get-token", "--offline"])
+    assert result.exit_code == 0
+    mock_token.assert_called_with(
+        environment=DeploymentEnvironment.staging,
+        auth_mode=AuthMode.pkce,
+        token_provider=TokenProvider.keycloak,
+        persistent_token_id=None,
+        offline=True,
         force_refresh=False,
     )
 
@@ -136,6 +162,7 @@ def test_get_token_force_refresh(mock_token, cli_runner):
         auth_mode=AuthMode.daf,
         token_provider=TokenProvider.keycloak,
         persistent_token_id=None,
+        offline=False,
         force_refresh=True,
     )
 
@@ -199,6 +226,7 @@ def test_get_user_info(mock_token, mock_user_info, cli_runner):
         auth_mode=AuthMode.daf,
         token_provider=TokenProvider.keycloak,
         persistent_token_id=None,
+        offline=False,
         force_refresh=False,
     )
     mock_user_info.assert_called_once_with(
@@ -222,6 +250,7 @@ def test_get_user_info_defaults(mock_token, mock_user_info, cli_runner):
         auth_mode=AuthMode.pkce,
         token_provider=TokenProvider.keycloak,
         persistent_token_id=None,
+        offline=False,
         force_refresh=False,
     )
     mock_user_info.assert_called_once_with(
@@ -245,6 +274,7 @@ def test_get_user_info_force_refresh(mock_token, mock_user_info, cli_runner):
         auth_mode=AuthMode.pkce,
         token_provider=TokenProvider.keycloak,
         persistent_token_id=None,
+        offline=False,
         force_refresh=True,
     )
     mock_user_info.assert_called_once_with("fresh-token", environment=DeploymentEnvironment.staging)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -43,6 +43,88 @@ def test_get_token_auth_manager(mock_cache, mock_method, mock_auth_manager):
 
 
 @patch(
+    "obi_auth.client.auth_manager_exchange_for_offline_token",
+    return_value=AuthManagerTokenInfo(
+        access_token="offline-token",  # noqa: S106
+        persistent_token_id="offline-id",  # noqa: S106
+    ),
+)
+@patch("obi_auth.client._get_auth_method")
+@patch("obi_auth.client._AUTH_MANAGER_TOKEN_CACHE")
+@patch("obi_auth.client.Storage")
+def test_get_token_auth_manager_offline(mock_storage, mock_cache, mock_method, mock_offline):
+    mock_cache.get.return_value = None
+    keycloak_token = KeycloakTokenInfo(access_token="keycloak-token")  # noqa: S106
+    mock_method.return_value = lambda *args, **kwargs: keycloak_token
+
+    assert (
+        test_module.get_token(token_provider=TokenProvider.auth_manager, offline=True)
+        == "offline-token"
+    )
+    mock_offline.assert_called_once()
+    assert mock_offline.call_args.args[0] == keycloak_token
+    assert mock_storage.call_args.kwargs["key"] == "pkce_auth_manager_offline"
+    mock_cache.set.assert_called_once()
+
+
+@patch(
+    "obi_auth.client.auth_manager_exchange_for_offline_token",
+    return_value=AuthManagerTokenInfo(
+        access_token="offline-token",  # noqa: S106
+        persistent_token_id="offline-id",  # noqa: S106
+    ),
+)
+@patch("obi_auth.client._get_auth_method")
+@patch("obi_auth.client._AUTH_MANAGER_TOKEN_CACHE")
+@patch("obi_auth.client.Storage")
+def test_get_token_offline_implies_auth_manager(
+    mock_storage, mock_cache, mock_method, mock_offline
+):
+    mock_cache.get.return_value = None
+    keycloak_token = KeycloakTokenInfo(access_token="keycloak-token")  # noqa: S106
+    mock_method.return_value = lambda *args, **kwargs: keycloak_token
+
+    assert test_module.get_token(offline=True) == "offline-token"
+    mock_offline.assert_called_once()
+    assert mock_storage.call_args.kwargs["key"] == "pkce_auth_manager_offline"
+
+
+@patch(
+    "obi_auth.client.auth_manager_exchange_for_offline_token",
+    side_effect=exception.AuthFlowError(),
+)
+@patch("obi_auth.client._get_auth_method")
+@patch("obi_auth.client._AUTH_MANAGER_TOKEN_CACHE")
+def test_get_token_auth_manager_offline_raises(mock_cache, mock_method, mock_offline):
+    mock_cache.get.return_value = None
+    mock_method.return_value = lambda *args, **kwargs: KeycloakTokenInfo(
+        access_token="keycloak-token"  # noqa: S106
+    )
+
+    with pytest.raises(exception.ClientError, match="Authentication process failed."):
+        test_module.get_token(token_provider=TokenProvider.auth_manager, offline=True)
+
+
+@patch("obi_auth.client.auth_manager_exchange_for_offline_token")
+@patch("obi_auth.client._get_auth_method")
+@patch("obi_auth.client._AUTH_MANAGER_TOKEN_CACHE")
+def test_get_token_auth_manager_offline_returns_none_access_token(
+    mock_cache, mock_method, mock_offline
+):
+    mock_cache.get.return_value = None
+    mock_method.return_value = lambda *args, **kwargs: KeycloakTokenInfo(
+        access_token="keycloak-token"  # noqa: S106
+    )
+    mock_offline.return_value = AuthManagerTokenInfo(
+        access_token=None,
+        persistent_token_id="offline-id",  # noqa: S106
+    )
+
+    with pytest.raises(exception.ClientError, match="Authentication process failed."):
+        test_module.get_token(token_provider=TokenProvider.auth_manager, offline=True)
+
+
+@patch(
     "obi_auth.client.auth_manager_mint_access_token",
     return_value=AuthManagerTokenInfo(
         access_token="minted-token",  # noqa: S106

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -43,16 +43,25 @@ def test_get_token_auth_manager(mock_cache, mock_method, mock_auth_manager):
 
 
 @patch(
-    "obi_auth.client.auth_manager_exchange_for_offline_token",
+    "obi_auth.client.auth_manager_upgrade_to_offline_token",
     return_value=AuthManagerTokenInfo(
         access_token="offline-token",  # noqa: S106
         persistent_token_id="offline-id",  # noqa: S106
     ),
 )
+@patch(
+    "obi_auth.client.auth_manager_exchange_token",
+    return_value=AuthManagerTokenInfo(
+        access_token="session-token",  # noqa: S106
+        persistent_token_id="session-id",  # noqa: S106
+    ),
+)
 @patch("obi_auth.client._get_auth_method")
 @patch("obi_auth.client._AUTH_MANAGER_TOKEN_CACHE")
 @patch("obi_auth.client.Storage")
-def test_get_token_auth_manager_offline(mock_storage, mock_cache, mock_method, mock_offline):
+def test_get_token_auth_manager_offline(
+    mock_storage, mock_cache, mock_method, mock_exchange, mock_upgrade
+):
     mock_cache.get.return_value = None
     keycloak_token = KeycloakTokenInfo(access_token="keycloak-token")  # noqa: S106
     mock_method.return_value = lambda *args, **kwargs: keycloak_token
@@ -61,41 +70,60 @@ def test_get_token_auth_manager_offline(mock_storage, mock_cache, mock_method, m
         test_module.get_token(token_provider=TokenProvider.auth_manager, offline=True)
         == "offline-token"
     )
-    mock_offline.assert_called_once()
-    assert mock_offline.call_args.args[0] == keycloak_token
+    mock_exchange.assert_called_once()
+    assert mock_exchange.call_args.args[0] == keycloak_token
+    mock_upgrade.assert_called_once()
+    assert mock_upgrade.call_args.args[0].access_token == "session-token"  # noqa: S105
     assert mock_storage.call_args.kwargs["key"] == "pkce_auth_manager_offline"
     mock_cache.set.assert_called_once()
 
 
 @patch(
-    "obi_auth.client.auth_manager_exchange_for_offline_token",
+    "obi_auth.client.auth_manager_upgrade_to_offline_token",
     return_value=AuthManagerTokenInfo(
         access_token="offline-token",  # noqa: S106
         persistent_token_id="offline-id",  # noqa: S106
+    ),
+)
+@patch(
+    "obi_auth.client.auth_manager_exchange_token",
+    return_value=AuthManagerTokenInfo(
+        access_token="session-token",  # noqa: S106
+        persistent_token_id="session-id",  # noqa: S106
     ),
 )
 @patch("obi_auth.client._get_auth_method")
 @patch("obi_auth.client._AUTH_MANAGER_TOKEN_CACHE")
 @patch("obi_auth.client.Storage")
 def test_get_token_offline_implies_auth_manager(
-    mock_storage, mock_cache, mock_method, mock_offline
+    mock_storage, mock_cache, mock_method, mock_exchange, mock_upgrade
 ):
     mock_cache.get.return_value = None
     keycloak_token = KeycloakTokenInfo(access_token="keycloak-token")  # noqa: S106
     mock_method.return_value = lambda *args, **kwargs: keycloak_token
 
     assert test_module.get_token(offline=True) == "offline-token"
-    mock_offline.assert_called_once()
+    mock_exchange.assert_called_once()
+    mock_upgrade.assert_called_once()
     assert mock_storage.call_args.kwargs["key"] == "pkce_auth_manager_offline"
 
 
 @patch(
-    "obi_auth.client.auth_manager_exchange_for_offline_token",
+    "obi_auth.client.auth_manager_upgrade_to_offline_token",
     side_effect=exception.AuthFlowError(),
+)
+@patch(
+    "obi_auth.client.auth_manager_exchange_token",
+    return_value=AuthManagerTokenInfo(
+        access_token="session-token",  # noqa: S106
+        persistent_token_id="session-id",  # noqa: S106
+    ),
 )
 @patch("obi_auth.client._get_auth_method")
 @patch("obi_auth.client._AUTH_MANAGER_TOKEN_CACHE")
-def test_get_token_auth_manager_offline_raises(mock_cache, mock_method, mock_offline):
+def test_get_token_auth_manager_offline_upgrade_raises(
+    mock_cache, mock_method, mock_exchange, mock_upgrade
+):
     mock_cache.get.return_value = None
     mock_method.return_value = lambda *args, **kwargs: KeycloakTokenInfo(
         access_token="keycloak-token"  # noqa: S106
@@ -104,18 +132,52 @@ def test_get_token_auth_manager_offline_raises(mock_cache, mock_method, mock_off
     with pytest.raises(exception.ClientError, match="Authentication process failed."):
         test_module.get_token(token_provider=TokenProvider.auth_manager, offline=True)
 
+    mock_exchange.assert_called_once()
+    mock_upgrade.assert_called_once()
+    mock_cache.set.assert_not_called()
 
-@patch("obi_auth.client.auth_manager_exchange_for_offline_token")
+
+@patch("obi_auth.client.auth_manager_upgrade_to_offline_token")
+@patch(
+    "obi_auth.client.auth_manager_exchange_token",
+    side_effect=exception.AuthFlowError(),
+)
 @patch("obi_auth.client._get_auth_method")
 @patch("obi_auth.client._AUTH_MANAGER_TOKEN_CACHE")
-def test_get_token_auth_manager_offline_returns_none_access_token(
-    mock_cache, mock_method, mock_offline
+def test_get_token_auth_manager_offline_exchange_raises(
+    mock_cache, mock_method, mock_exchange, mock_upgrade
 ):
     mock_cache.get.return_value = None
     mock_method.return_value = lambda *args, **kwargs: KeycloakTokenInfo(
         access_token="keycloak-token"  # noqa: S106
     )
-    mock_offline.return_value = AuthManagerTokenInfo(
+
+    with pytest.raises(exception.ClientError, match="Authentication process failed."):
+        test_module.get_token(token_provider=TokenProvider.auth_manager, offline=True)
+
+    mock_exchange.assert_called_once()
+    mock_upgrade.assert_not_called()
+    mock_cache.set.assert_not_called()
+
+
+@patch("obi_auth.client.auth_manager_upgrade_to_offline_token")
+@patch(
+    "obi_auth.client.auth_manager_exchange_token",
+    return_value=AuthManagerTokenInfo(
+        access_token="session-token",  # noqa: S106
+        persistent_token_id="session-id",  # noqa: S106
+    ),
+)
+@patch("obi_auth.client._get_auth_method")
+@patch("obi_auth.client._AUTH_MANAGER_TOKEN_CACHE")
+def test_get_token_auth_manager_offline_returns_none_access_token(
+    mock_cache, mock_method, mock_exchange, mock_upgrade
+):
+    mock_cache.get.return_value = None
+    mock_method.return_value = lambda *args, **kwargs: KeycloakTokenInfo(
+        access_token="keycloak-token"  # noqa: S106
+    )
+    mock_upgrade.return_value = AuthManagerTokenInfo(
         access_token=None,
         persistent_token_id="offline-id",  # noqa: S106
     )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -118,3 +118,19 @@ def test_get_auth_manager_token_exchange_endpoint(settings):
 
     res = settings.get_auth_manager_token_exchange_endpoint(override_env="production")
     assert res == f"{PROD_OBI_URL}/api/auth-manager/v1/token-exchange"
+
+
+def test_get_auth_manager_offline_token_endpoint(settings):
+    res = settings.get_auth_manager_offline_token_endpoint()
+    assert res == f"{STAGING_OBI_URL}/api/auth-manager/v1/offline-token"
+
+    res = settings.get_auth_manager_offline_token_endpoint(override_env="production")
+    assert res == f"{PROD_OBI_URL}/api/auth-manager/v1/offline-token"
+
+
+def test_get_auth_manager_offline_token_id_endpoint(settings):
+    res = settings.get_auth_manager_offline_token_id_endpoint()
+    assert res == f"{STAGING_OBI_URL}/api/auth-manager/v1/offline-token-id"
+
+    res = settings.get_auth_manager_offline_token_id_endpoint(override_env="production")
+    assert res == f"{PROD_OBI_URL}/api/auth-manager/v1/offline-token-id"


### PR DESCRIPTION
## Summary
- Add `offline=True` / `--offline` to exchange via auth-manager, obtain an offline vault id (Keycloak `offline_access` consent when needed), and mint an access token.
- `--offline` implies `token_provider=auth_manager` so `obi-auth get-token --offline` works without `-p`.
- Send interactive consent/DAF prompts to stderr so stdout stays a single token suitable for piping into `decode-token`.